### PR TITLE
refactor: add ConditionalOnProperty to RelationUpdateConsumer to enab…

### DIFF
--- a/src/main/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumer.kt
@@ -16,7 +16,11 @@ open class RelationUpdateConsumer(
     private val consumerConfig: ConsumerConfiguration,
 ) {
     @Bean
-    @ConditionalOnProperty(name = ["fint.consumer.autorelation"], havingValue = "true")
+    @ConditionalOnProperty(
+        name = ["fint.consumer.autorelation"],
+        havingValue = "true",
+        matchIfMissing = true,
+    )
     open fun relationUpdateConsumerContainer(consumerFactoryService: EntityConsumerFactoryService) =
         consumerFactoryService
             .createFactory(RelationUpdate::class.java, this::consumeRecord)

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumer.kt
@@ -6,33 +6,35 @@ import no.fintlabs.consumer.links.relation.RelationService
 import no.fintlabs.kafka.entity.EntityConsumerFactoryService
 import no.fintlabs.kafka.entity.topic.EntityTopicNameParameters
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.stereotype.Component
 
 @Configuration
 open class RelationUpdateConsumer(
     private val relationService: RelationService,
-    private val consumerConfig: ConsumerConfiguration
+    private val consumerConfig: ConsumerConfiguration,
 ) {
-
     @Bean
+    @ConditionalOnProperty(name = ["fint.consumer.autorelation"], havingValue = "true")
     open fun relationUpdateConsumerContainer(consumerFactoryService: EntityConsumerFactoryService) =
         consumerFactoryService
             .createFactory(RelationUpdate::class.java, this::consumeRecord)
             .createContainer(
-                EntityTopicNameParameters.builder()
+                EntityTopicNameParameters
+                    .builder()
                     .orgId("fintlabs-no")
                     .domainContext("fint-core")
                     .resource("relation-update")
-                    .build()
+                    .build(),
             )
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String, RelationUpdate>) =
-        consumerRecord.value().takeIf { belongsToThisService(it) }
+        consumerRecord
+            .value()
+            .takeIf { belongsToThisService(it) }
             ?.let { relationService.processRelationUpdate(it) }
 
     private fun belongsToThisService(relationUpdate: RelationUpdate) =
         consumerConfig.matchesConfiguration(relationUpdate.domainName, relationUpdate.packageName, relationUpdate.orgId)
-
 }


### PR DESCRIPTION
Sdworx har problemer pga en autorelasjon bug. Tenker det er greit at vi har konfigurasjon for å velge om vi skal lytte på relasjons oppdateringer eller ikke. Vi sender fremdeles "relation-request", det er pga vi ønsker fremdeles å fortelle autorelasjon tjenesten om endringer. Men det betyr ikke at vi trenger i lytte på dem.