### PR TITLE
fix: recursively check relations for their own common resources while…

### DIFF
--- a/src/main/java/no/fintlabs/consumer/resource/context/ResourceContextCache.java
+++ b/src/main/java/no/fintlabs/consumer/resource/context/ResourceContextCache.java
@@ -13,10 +13,7 @@ import no.fintlabs.reflection.ReflectionCache;
 import no.fintlabs.reflection.ReflectionInitializer;
 import org.springframework.stereotype.Component;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -78,7 +75,11 @@ public class ResourceContextCache {
                 .filter(relation -> isACommonResource(relation.packageName()))
                 .map(relation -> reflectionCache.getMetaSubtype(relation.packageName()))
                 .map(this::createFintResourceInformation)
-                .forEach(this::addResourceInformation);
+                .filter(ri -> !resourceMap.containsKey(ri.name()))
+                .forEach(fintResourceInformation -> {
+                    addResourceInformation(fintResourceInformation);
+                    checkRelationsForCommonResources(fintResourceInformation.relations().values());
+                });
     }
 
     private FintRelationInformation createFintRelationInformation(FintRelation fintRelation) {

--- a/src/main/java/no/fintlabs/consumer/resource/context/ResourceContextCache.java
+++ b/src/main/java/no/fintlabs/consumer/resource/context/ResourceContextCache.java
@@ -13,7 +13,10 @@ import no.fintlabs.reflection.ReflectionCache;
 import no.fintlabs.reflection.ReflectionInitializer;
 import org.springframework.stereotype.Component;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -75,7 +78,7 @@ public class ResourceContextCache {
                 .filter(relation -> isACommonResource(relation.packageName()))
                 .map(relation -> reflectionCache.getMetaSubtype(relation.packageName()))
                 .map(this::createFintResourceInformation)
-                .filter(ri -> !resourceMap.containsKey(ri.name()))
+                .filter(resourceInformation -> !resourceMap.containsKey(resourceInformation.name()))
                 .forEach(fintResourceInformation -> {
                     addResourceInformation(fintResourceInformation);
                     checkRelationsForCommonResources(fintResourceInformation.relations().values());


### PR DESCRIPTION
kontaktperson er en felles ressurs som i dag blir ikke tatt med i consumeren. Dette er fordi vi gjør kunn en sjekk på hoved ressurser sine relasjoner. Om en relasjon er felles i en hovedrelasjon, så inkluderer vi den. Om det er en felles ressurs som er en relasjon fra en annen felles ressurs, så blir den ikke tatt med. Disse endringene løser dette problemet.

Kontaktperson er nå en del av utdanning-elev