### PR TITLE
feat: add header core version header to all responses

### DIFF
--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -10,6 +10,7 @@ data class ConsumerConfiguration(
     val packageName: String,
     val podUrl: String,
     var autorelation: Boolean = true,
+    val coreVersionHeader: String = "2",
 ) {
     val componentUrl: String
         get() = "$baseUrl/$domain/$packageName"

--- a/src/main/java/no/fintlabs/consumer/config/WebFluxConfig.java
+++ b/src/main/java/no/fintlabs/consumer/config/WebFluxConfig.java
@@ -1,15 +1,37 @@
 package no.fintlabs.consumer.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.config.PathMatchConfigurer;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.server.WebFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebFluxConfig implements WebFluxConfigurer {
+    private final ConsumerConfiguration consumerConfiguration;
+
+    private static final String CORE_VERSION_HEADER = "x-core-version";
 
     @Override
     public void configurePathMatching(PathMatchConfigurer configurer) {
         configurer.setUseTrailingSlashMatch(true);
     }
 
+    /*
+     * Adds core version header to all HTTP responses
+     */
+    @Bean
+    public WebFilter coreVersionHeaderFilter() {
+        return (exchange, chain) -> {
+            HttpHeaders headers = exchange.getResponse().getHeaders();
+            if (!headers.containsKey(CORE_VERSION_HEADER)) {
+                headers.add(CORE_VERSION_HEADER, consumerConfiguration.getCoreVersionHeader());
+            }
+            return chain.filter(exchange);
+        };
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -19,6 +19,7 @@ fint:
     package: vurdering
     packageName: ${fint.consumer.package}
     org-id: ${fint.org-id}
+    coreVersionHeader: 2
 
 spring:
   kafka:


### PR DESCRIPTION
Add x-core-version header.
Used by developers of adapters to ensure we are connecting to the correct backend in the transitioning period.