### PR TITLE
refactor: get resource name from header or throw exception

### DIFF
--- a/src/integrationTest/java/no/fintlabs/consumer/integration/AutoRelationIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/AutoRelationIT.kt
@@ -11,10 +11,7 @@ import no.fintlabs.autorelation.model.RelationOperation
 import no.fintlabs.autorelation.model.RelationUpdate
 import no.fintlabs.cache.CacheService
 import no.fintlabs.consumer.config.OrgId
-import no.fintlabs.consumer.kafka.KafkaConstants.LAST_MODIFIED
-import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_CORRELATION_ID
-import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TOTAL_SIZE
-import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TYPE
+import no.fintlabs.consumer.kafka.KafkaConstants.*
 import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
 import no.novari.fint.model.resource.FintResource
 import no.novari.fint.model.resource.Link
@@ -43,7 +40,7 @@ import org.springframework.test.context.TestPropertySource
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Duration
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -304,12 +301,8 @@ class AutoRelationIT {
         headers.add(RecordHeader(LAST_MODIFIED, ByteBuffer.allocate(Long.SIZE_BYTES).putLong(timestamp).array()))
         headers.add(RecordHeader(SYNC_TYPE, byteArrayOf(SyncType.FULL.ordinal.toByte())))
         headers.add(RecordHeader(SYNC_CORRELATION_ID, corrId.toByteArray()))
-        headers.add(
-            RecordHeader(
-                SYNC_TOTAL_SIZE,
-                ByteBuffer.allocate(Long.SIZE_BYTES).putLong(1).array(),
-            ),
-        )
+        headers.add(RecordHeader(SYNC_TOTAL_SIZE, ByteBuffer.allocate(Long.SIZE_BYTES).putLong(1).array()))
+        headers.add(RecordHeader(RESOURCE_NAME, resourceName.toByteArray()))
 
         val key =
             requireNotNull(resource.identifikators["systemId"]?.identifikatorverdi) {

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/AutoRelationIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/AutoRelationIT.kt
@@ -11,7 +11,11 @@ import no.fintlabs.autorelation.model.RelationOperation
 import no.fintlabs.autorelation.model.RelationUpdate
 import no.fintlabs.cache.CacheService
 import no.fintlabs.consumer.config.OrgId
-import no.fintlabs.consumer.kafka.KafkaConstants.*
+import no.fintlabs.consumer.kafka.KafkaConstants.LAST_MODIFIED
+import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
+import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_CORRELATION_ID
+import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TOTAL_SIZE
+import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TYPE
 import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
 import no.novari.fint.model.resource.FintResource
 import no.novari.fint.model.resource.Link
@@ -40,7 +44,7 @@ import org.springframework.test.context.TestPropertySource
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Duration
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -50,7 +54,7 @@ import kotlin.test.assertTrue
 @EmbeddedKafka(
     partitions = 1,
     topics = [
-        "foo-org.fint-core.entity.utdanning-vurdering-elevfravar",
+        "foo-org.fint-core.entity.utdanning-vurdering",
         "foo-org.fint-core.event.relation-update",
     ],
 )
@@ -101,7 +105,7 @@ class AutoRelationIT {
     lateinit var unresolvedRelationCache: UnresolvedRelationCache
 
     private lateinit var kafkaTemplate: KafkaTemplate<String, String>
-    private lateinit var elevfravarEntityTopic: String
+    private lateinit var entityTopic: String
 
     private val clock: Clock = Clock.systemUTC()
     private val resourceName = "elevfravar"
@@ -122,8 +126,8 @@ class AutoRelationIT {
             }
         kafkaTemplate = KafkaTemplate(DefaultKafkaProducerFactory(producerProps))
 
-        elevfravarEntityTopic =
-            "${OrgId.from(fintOrg).asTopicSegment}.fint-core.entity.$fintDomain-$fintPackage-$resourceName"
+        entityTopic =
+            "${OrgId.from(fintOrg).asTopicSegment}.fint-core.entity.$fintDomain-$fintPackage"
     }
 
     @AfterEach
@@ -310,7 +314,7 @@ class AutoRelationIT {
             }
         val value = objectMapper.writeValueAsString(resource)
         kafkaTemplate
-            .send(ProducerRecord(elevfravarEntityTopic, null, timestamp, key, value, headers))
+            .send(ProducerRecord(entityTopic, null, timestamp, key, value, headers))
             .get(10, TimeUnit.SECONDS)
     }
 

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/FintCacheIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/FintCacheIT.kt
@@ -6,6 +6,7 @@ import no.fintlabs.adapter.models.sync.SyncType
 import no.fintlabs.cache.CacheService
 import no.fintlabs.consumer.config.OrgId
 import no.fintlabs.consumer.kafka.KafkaConstants.LAST_MODIFIED
+import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
 import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_CORRELATION_ID
 import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TOTAL_SIZE
 import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TYPE
@@ -40,7 +41,7 @@ import org.springframework.web.client.ResponseErrorHandler
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Duration
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -51,7 +52,7 @@ fun constructEntityTopic(
     resourceName: String,
 ) = "${OrgId.from(org).asTopicSegment}.$domain.entity.$resourceName"
 
-const val FAG_ENTITY_TOPIC = "foo-org.fint-core.entity.utdanning-timeplan-fag"
+const val FAG_ENTITY_TOPIC = "foo-org.fint-core.entity.utdanning-timeplan"
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
 @EmbeddedKafka(
@@ -124,9 +125,8 @@ class FintCacheIT {
             }
 
         kafkaTemplate = KafkaTemplate(DefaultKafkaProducerFactory(producerProps))
-        fagEntityTopic = constructEntityTopic(fintOrg, "fint-core", "$fintDomain-$fintPackage-fag")
-        undervisningsgruppeEntityTopic =
-            constructEntityTopic(fintOrg, "fint-core", "$fintDomain-$fintPackage-undervisningsgruppe")
+        fagEntityTopic = constructEntityTopic(fintOrg, "fint-core", "$fintDomain-$fintPackage")
+        undervisningsgruppeEntityTopic = constructEntityTopic(fintOrg, "fint-core", "$fintDomain-$fintPackage")
     }
 
     @AfterEach
@@ -246,7 +246,7 @@ class FintCacheIT {
         val fagC = updateFag("C", corrId = corrIdFirst, totalSize = 2)
 
         // Delete sync
-        deleteFag("B", FagResource::class.java)
+        deleteFag("B")
 
         await.atMost(Duration.ofSeconds(10)).untilAsserted {
             val fagResources = fetchAllFagResources()
@@ -265,8 +265,8 @@ class FintCacheIT {
 
         // Delete-sync removing all resources
         val corrIdDelete = UUID.randomUUID().toString()
-        deleteFag("B", FagResource::class.java, correlationId = corrIdDelete, totalSize = 2)
-        deleteFag("C", FagResource::class.java, correlationId = corrIdDelete, totalSize = 2)
+        deleteFag("B", correlationId = corrIdDelete, totalSize = 2)
+        deleteFag("C", correlationId = corrIdDelete, totalSize = 2)
 
         await.atMost(Duration.ofSeconds(10)).untilAsserted {
             val fagResources = fetchAllFagResources()
@@ -373,7 +373,7 @@ class FintCacheIT {
         descriptionToken: String = "",
     ): FintResource {
         val fag = createFagDto("systemid-fag-$id", "Fag-$id", "Beskrivelse fag $id $descriptionToken")
-        sendKafkaEntityRecord(fag, timestamp, syncType, totalSize, corrId)
+        sendKafkaEntityRecord(fag, timestamp, syncType, totalSize, corrId, resourceName = "fag")
         return fag
     }
 
@@ -383,12 +383,8 @@ class FintCacheIT {
         syncType: SyncType,
         totalSize: Int,
         correlationId: String = UUID.randomUUID().toString(),
+        resourceName: String,
     ) {
-        val topic =
-            when (resource) {
-                is FagResource -> fagEntityTopic
-                else -> undervisningsgruppeEntityTopic
-            }
         val key =
             requireNotNull(resource.identifikators["systemId"]?.identifikatorverdi) {
                 "Missing value for systemId identifikatorverdi"
@@ -404,33 +400,31 @@ class FintCacheIT {
                 ByteBuffer.allocate(Long.SIZE_BYTES).putLong(totalSize.toLong()).array(),
             ),
         )
-        kafkaTemplate.send(ProducerRecord(topic, null, timestamp, key, value, recordHeaders)).get(10, TimeUnit.SECONDS)
+        recordHeaders.add(RecordHeader(RESOURCE_NAME, resourceName.toByteArray()))
+        kafkaTemplate
+            .send(ProducerRecord(fagEntityTopic, null, timestamp, key, value, recordHeaders))
+            .get(10, TimeUnit.SECONDS)
     }
 
-    private fun <T> deleteFag(
+    private fun deleteFag(
         id: String,
-        resourceType: Class<T>,
         timestamp: Long = clock.millis(),
         totalSize: Long = 1,
         correlationId: String = UUID.randomUUID().toString(),
     ) {
-        val topic =
-            when (resourceType) {
-                FagResource::class.java -> fagEntityTopic
-                else -> undervisningsgruppeEntityTopic
-            }
         val key = "systemid-fag-$id"
         val recordHeaders = RecordHeaders()
         recordHeaders.add(LAST_MODIFIED, ByteBuffer.allocate(8).putLong(timestamp).array())
         recordHeaders.add(RecordHeader(SYNC_TYPE, byteArrayOf(SyncType.DELETE.ordinal.toByte())))
         recordHeaders.add(RecordHeader(SYNC_CORRELATION_ID, correlationId.toByteArray()))
         recordHeaders.add(
-            RecordHeader(
-                SYNC_TOTAL_SIZE,
-                ByteBuffer.allocate(Long.SIZE_BYTES).putLong(totalSize).array(),
-            ),
+            RecordHeader(SYNC_TOTAL_SIZE, ByteBuffer.allocate(Long.SIZE_BYTES).putLong(totalSize).array()),
         )
-        kafkaTemplate.send(ProducerRecord(topic, null, timestamp, key, null, recordHeaders)).get(10, TimeUnit.SECONDS)
+        recordHeaders.add(RecordHeader(RESOURCE_NAME, "fag".toByteArray()))
+        kafkaTemplate
+            .send(
+                ProducerRecord(fagEntityTopic, null, timestamp, key, null, recordHeaders),
+            ).get(10, TimeUnit.SECONDS)
     }
 
     private fun fetchAllFag(): FintResourcesPage {

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/FintCacheIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/FintCacheIT.kt
@@ -41,7 +41,7 @@ import org.springframework.web.client.ResponseErrorHandler
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Duration
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/ManyToManyAutoRelationIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/ManyToManyAutoRelationIT.kt
@@ -49,8 +49,7 @@ fun constructAutorelationEntityTopic(
 @EmbeddedKafka(
     partitions = 1,
     topics = [
-        "foo-org.fint-core.entity.utdanning-elev-undervisningsforhold",
-        "foo-org.fint-core.entity.utdanning-elev-kontaktlarergruppe",
+        "foo-org.fint-core.entity.utdanning-elev",
         "foo-org.fint-core.event.relation-update",
     ],
 )
@@ -94,8 +93,7 @@ class ManyToManyAutoRelationIT {
 
     private lateinit var kafkaTemplate: KafkaTemplate<String, String>
 
-    private lateinit var undervisningsforholdEntityTopic: String
-    private lateinit var kontaktlarergruppeEntityTopic: String
+    private lateinit var entityTopic: String
 
     private val clock: Clock = Clock.systemUTC()
 
@@ -124,10 +122,7 @@ class ManyToManyAutoRelationIT {
 
         kafkaTemplate = KafkaTemplate(DefaultKafkaProducerFactory(producerProps))
 
-        undervisningsforholdEntityTopic =
-            constructAutorelationEntityTopic(fintOrg, "fint-core", "$fintDomain-$fintPackage-undervisningsforhold")
-        kontaktlarergruppeEntityTopic =
-            constructAutorelationEntityTopic(fintOrg, "fint-core", "$fintDomain-$fintPackage-kontaktlarergruppe")
+        entityTopic = constructAutorelationEntityTopic(fintOrg, "fint-core", "$fintDomain-$fintPackage")
     }
 
     @AfterEach
@@ -261,13 +256,6 @@ class ManyToManyAutoRelationIT {
         totalSize: Int = 1,
         timestamp: Long = clock.millis(),
     ) {
-        val topic =
-            when (resourceName) {
-                "undervisningsforhold" -> undervisningsforholdEntityTopic
-                "kontaktlarergruppe" -> kontaktlarergruppeEntityTopic
-                else -> throw IllegalArgumentException("Unknown resourceName $resourceName")
-            }
-
         val key =
             requireNotNull(resource.identifikators["systemId"]?.identifikatorverdi) {
                 "Missing value for systemId identifikatorverdi"
@@ -283,7 +271,11 @@ class ManyToManyAutoRelationIT {
                 ByteBuffer.allocate(Long.SIZE_BYTES).putLong(totalSize.toLong()).array(),
             ),
         )
-        kafkaTemplate.send(ProducerRecord(topic, null, timestamp, key, value, recordHeaders)).get(10, TimeUnit.SECONDS)
+        recordHeaders.add(RecordHeader(KafkaConstants.RESOURCE_NAME, resourceName.toByteArray()))
+        kafkaTemplate
+            .send(
+                ProducerRecord(entityTopic, null, timestamp, key, value, recordHeaders),
+            ).get(10, TimeUnit.SECONDS)
     }
 
     private fun assertLinkExistsOnUndervisningsforhold(undervisningId: String) {

--- a/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
@@ -58,8 +58,11 @@ class AutoRelationEntityConsumer(
                             .orgId(TopicNamePatternParameterPattern.anyOf(consumerConfig.orgId.asTopicSegment))
                             .domainContextApplicationDefault()
                             .build(),
-                    ).resource(TopicNamePatternParameterPattern.startingWith(createResourcePattern()))
-                    .build(),
+                    ).resource(
+                        TopicNamePatternParameterPattern.endingWith(
+                            "${consumerConfig.domain}-${consumerConfig.packageName}",
+                        ),
+                    ).build(),
             ).apply { concurrency = consumerConfig.kafka.entityConcurrency }
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String, Any?>) {
@@ -73,8 +76,6 @@ class AutoRelationEntityConsumer(
                 )
             }
     }
-
-    private fun createResourcePattern() = "${consumerConfig.domain}-${consumerConfig.packageName}"
 
     private fun ConsumerRecord<String, Any?>.getResourceName(): String =
         headers().stringValue(RESOURCE_NAME) ?: throw IllegalArgumentException("Resource name header not found")

--- a/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
@@ -2,7 +2,9 @@ package no.fintlabs.autorelation.kafka
 
 import no.fintlabs.autorelation.RelationEventService
 import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
+import no.fintlabs.consumer.kafka.stringValue
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
@@ -29,8 +31,8 @@ class AutoRelationEntityConsumer(
     fun buildAutoRelationConsumer(
         parameterizedListenerContainerFactoryService: ParameterizedListenerContainerFactoryService,
         errorHandlerFactory: ErrorHandlerFactory,
-    ): ConcurrentMessageListenerContainer<String, in Any> {
-        return parameterizedListenerContainerFactoryService
+    ): ConcurrentMessageListenerContainer<String, in Any> =
+        parameterizedListenerContainerFactoryService
             .createRecordListenerContainerFactory(
                 Any::class.java,
                 this::consumeRecord,
@@ -59,14 +61,13 @@ class AutoRelationEntityConsumer(
                     ).resource(TopicNamePatternParameterPattern.startingWith(createResourcePattern()))
                     .build(),
             ).apply { concurrency = consumerConfig.kafka.entityConcurrency }
-    }
 
-    fun consumeRecord(consumerRecord: ConsumerRecord<String, Any>) {
+    fun consumeRecord(consumerRecord: ConsumerRecord<String, Any?>) {
         consumerRecord
             .value()
             ?.let { resource ->
                 relationEventService.addRelations(
-                    consumerRecord.resourceName(),
+                    consumerRecord.getResourceName(),
                     consumerRecord.key(),
                     resource,
                 )
@@ -75,5 +76,6 @@ class AutoRelationEntityConsumer(
 
     private fun createResourcePattern() = "${consumerConfig.domain}-${consumerConfig.packageName}"
 
-    private fun ConsumerRecord<String, in Any>.resourceName(): String = topic().substringAfterLast("-")
+    private fun ConsumerRecord<String, Any?>.getResourceName(): String =
+        headers().stringValue(RESOURCE_NAME) ?: throw IllegalArgumentException("Resource name header not found")
 }

--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -42,9 +42,15 @@ data class ConsumerConfiguration(
             this.orgId.matches(orgId)
 }
 
+// TODO: Cleanup configuration
 data class KafkaConfiguration(
+    // Entity consumption in EntityConsumer & AutoRelationEntityConsumer
     val entityConcurrency: Int = 1,
+    // RelationUpdate
     val relationConcurrency: Int = 1,
     val relationPartitions: Int = 1,
     val relationRetentionTime: Duration = Duration.ofDays(7),
+    // RequestFintEvent
+    val requestPartitions: Int = 1,
+    val requestRetentionTime: Duration = Duration.ofDays(7),
 )

--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -54,4 +54,6 @@ data class KafkaConfiguration(
     val requestConcurrency: Int = 1,
     val requestPartitions: Int = 1,
     val requestRetentionTime: Duration = Duration.ofDays(7),
+    // ResponseFintEvent
+    val responseConcurrency: Int = 1,
 )

--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -51,6 +51,7 @@ data class KafkaConfiguration(
     val relationPartitions: Int = 1,
     val relationRetentionTime: Duration = Duration.ofDays(7),
     // RequestFintEvent
+    val requestConcurrency: Int = 1,
     val requestPartitions: Int = 1,
     val requestRetentionTime: Duration = Duration.ofDays(7),
 )

--- a/src/main/java/no/fintlabs/consumer/kafka/KafkaConstants.java
+++ b/src/main/java/no/fintlabs/consumer/kafka/KafkaConstants.java
@@ -8,5 +8,6 @@ public class KafkaConstants {
     public static String SYNC_TOTAL_SIZE = "sync-total-size";
     public static String SYNC_TYPE = "sync-type";
     public static String LAST_MODIFIED = ENTITY_RETENTION_TIME; // TODO: Deprecate ENTITY_RETENTION_TIME in the future, plan for removal in provider-gateway
+    public static String RESOURCE_NAME = "resource-name";
 
 }

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
@@ -1,9 +1,10 @@
 package no.fintlabs.consumer.kafka.entity
 
 import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
+import no.fintlabs.consumer.kafka.stringValue
 import no.fintlabs.consumer.resource.ResourceConverter
-import no.novari.fint.model.resource.FintResource
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
@@ -68,22 +69,16 @@ class EntityConsumer(
             .let { entityProcessingService.processEntityConsumerRecord(it) }
 
     private fun createEntityConsumerRecord(consumerRecord: ConsumerRecord<String, Any?>) =
-        getResourceName(consumerRecord.topic()).let { resourceName ->
-
+        consumerRecord.getResourceName().let { resourceName ->
             consumerRecord
                 .value()
                 ?.let { resourceConverter.convert(resourceName, it) }
-                ?.let { createKafkaEntity(resourceName, it, consumerRecord) }
-                ?: createKafkaEntity(resourceName, null, consumerRecord)
+                ?.let { EntityConsumerRecord(resourceName, it, consumerRecord) }
+                ?: EntityConsumerRecord(resourceName, null, consumerRecord)
         }
-
-    private fun createKafkaEntity(
-        resourceName: String,
-        resource: FintResource?,
-        consumerRecord: ConsumerRecord<String, Any?>,
-    ) = EntityConsumerRecord(resourceName, resource, record = consumerRecord)
 
     private fun createResourcePattern() = "${consumerConfig.domain}-${consumerConfig.packageName}"
 
-    private fun getResourceName(topic: String) = topic.substringAfterLast("-")
+    private fun ConsumerRecord<String, Any?>.getResourceName(): String =
+        headers().stringValue(RESOURCE_NAME) ?: throw IllegalArgumentException("Resource name header not found")
 }

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
@@ -59,8 +59,11 @@ class EntityConsumer(
                             .orgId(TopicNamePatternParameterPattern.anyOf(consumerConfig.orgId.asTopicSegment))
                             .domainContextApplicationDefault()
                             .build(),
-                    ).resource(TopicNamePatternParameterPattern.startingWith(createResourcePattern()))
-                    .build(),
+                    ).resource(
+                        TopicNamePatternParameterPattern.endingWith(
+                            "${consumerConfig.domain}-${consumerConfig.packageName}",
+                        ),
+                    ).build(),
             ).apply { concurrency = consumerConfig.kafka.entityConcurrency }
     }
 
@@ -76,8 +79,6 @@ class EntityConsumer(
                 ?.let { EntityConsumerRecord(resourceName, it, consumerRecord) }
                 ?: EntityConsumerRecord(resourceName, null, consumerRecord)
         }
-
-    private fun createResourcePattern() = "${consumerConfig.domain}-${consumerConfig.packageName}"
 
     private fun ConsumerRecord<String, Any?>.getResourceName(): String =
         headers().stringValue(RESOURCE_NAME) ?: throw IllegalArgumentException("Resource name header not found")

--- a/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
@@ -3,14 +3,12 @@ package no.fintlabs.consumer.kafka.event
 import no.fintlabs.adapter.models.event.ResponseFintEvent
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
-import no.fintlabs.consumer.resource.context.ResourceContext
 import no.fintlabs.consumer.resource.event.EventStatusCache
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
-import no.novari.kafka.topic.name.EventTopicNamePatternParameters
-import no.novari.kafka.topic.name.TopicNamePatternParameterPattern
-import no.novari.kafka.topic.name.TopicNamePatternPrefixParameters
+import no.novari.kafka.topic.name.EventTopicNameParameters
+import no.novari.kafka.topic.name.TopicNamePrefixParameters
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
@@ -19,16 +17,13 @@ import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
 
 @Configuration
 class EventResponseConsumer(
-    private val configuration: ConsumerConfiguration,
+    private val consumerConfig: ConsumerConfiguration,
     private val eventStatusCache: EventStatusCache,
 ) {
-    private val logger = LoggerFactory.getLogger(javaClass)
-
     @Bean
     fun responseFintEventContainerListener(
         parameterizedListenerContainerFactoryService: ParameterizedListenerContainerFactoryService,
         errorHandlerFactory: ErrorHandlerFactory,
-        resourceContext: ResourceContext,
     ): ConcurrentMessageListenerContainer<String, ResponseFintEvent> =
         parameterizedListenerContainerFactoryService
             .createRecordListenerContainerFactory(
@@ -48,28 +43,17 @@ class EventResponseConsumer(
                     ),
                 ),
             ).createContainer(
-                EventTopicNamePatternParameters
+                EventTopicNameParameters
                     .builder()
-                    .topicNamePatternPrefixParameters(
-                        TopicNamePatternPrefixParameters
+                    .topicNamePrefixParameters(
+                        TopicNamePrefixParameters
                             .stepBuilder()
-                            .orgId(TopicNamePatternParameterPattern.anyOf(configuration.orgId.asTopicSegment))
+                            .orgId(consumerConfig.orgId.asTopicSegment)
                             .domainContextApplicationDefault()
                             .build(),
-                    ).eventName(
-                        TopicNamePatternParameterPattern.anyOf(
-                            *createEventNames(resourceContext.resourceNames),
-                        ),
-                    ).build(),
-            )
-
-    private fun createEventNames(resourceNames: Set<String>): Array<String> =
-        resourceNames.map(::formatEventName).toTypedArray()
-
-    private fun formatEventName(resourceName: String): String =
-        with(configuration) {
-            "$domain-$packageName-$resourceName-response"
-        }
+                    ).eventName("${consumerConfig.domain}-${consumerConfig.packageName}-response")
+                    .build(),
+            ).apply { concurrency = consumerConfig.kafka.responseConcurrency }
 
     private fun consumeRecord(consumerRecord: ConsumerRecord<String, ResponseFintEvent>) {
         logger.info("Received Response: {}", consumerRecord.value())

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
@@ -19,7 +19,7 @@ import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
 
 @Configuration
 class RequestFintEventConsumer(
-    private val configuration: ConsumerConfiguration,
+    private val consumerConfig: ConsumerConfiguration,
     private val eventStatusCache: EventStatusCache,
 ) {
     companion object {
@@ -56,7 +56,7 @@ class RequestFintEventConsumer(
                     .topicNamePatternPrefixParameters(
                         TopicNamePatternPrefixParameters
                             .stepBuilder()
-                            .orgId(TopicNamePatternParameterPattern.anyOf(configuration.orgId.asTopicSegment))
+                            .orgId(TopicNamePatternParameterPattern.anyOf(consumerConfig.orgId.asTopicSegment))
                             .domainContextApplicationDefault()
                             .build(),
                     ).eventName(
@@ -64,13 +64,13 @@ class RequestFintEventConsumer(
                             *createEventNames(resourceContext.resourceNames),
                         ),
                     ).build(),
-            )
+            ).apply { concurrency = consumerConfig.kafka.requestConcurrency }
 
     private fun createEventNames(resourceNames: MutableSet<String>): Array<String> =
         resourceNames.map { formatEventName(it) }.toTypedArray()
 
     private fun formatEventName(resourceName: String?): String =
-        with(configuration) {
+        with(consumerConfig) {
             "$domain-$packageName-$resourceName-request"
         }
 

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
@@ -3,7 +3,6 @@ package no.fintlabs.consumer.kafka.event
 import no.fintlabs.adapter.models.event.RequestFintEvent
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
-import no.fintlabs.consumer.resource.context.ResourceContext
 import no.fintlabs.consumer.resource.event.EventStatusCache
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
@@ -31,7 +30,6 @@ class RequestFintEventConsumer(
     fun requestFintEventRequestListenerContainer(
         parameterizedListenerContainerFactoryService: ParameterizedListenerContainerFactoryService,
         errorHandlerFactory: ErrorHandlerFactory,
-        resourceContext: ResourceContext,
     ): ConcurrentMessageListenerContainer<String, RequestFintEvent> =
         parameterizedListenerContainerFactoryService
             .createRecordListenerContainerFactory(
@@ -60,19 +58,11 @@ class RequestFintEventConsumer(
                             .domainContextApplicationDefault()
                             .build(),
                     ).eventName(
-                        TopicNamePatternParameterPattern.anyOf(
-                            *createEventNames(resourceContext.resourceNames),
+                        TopicNamePatternParameterPattern.endingWith(
+                            "${consumerConfig.domain}-${consumerConfig.packageName}-request",
                         ),
                     ).build(),
             ).apply { concurrency = consumerConfig.kafka.requestConcurrency }
-
-    private fun createEventNames(resourceNames: MutableSet<String>): Array<String> =
-        resourceNames.map { formatEventName(it) }.toTypedArray()
-
-    private fun formatEventName(resourceName: String?): String =
-        with(consumerConfig) {
-            "$domain-$packageName-$resourceName-request"
-        }
 
     private fun consumeRecord(consumerRecord: ConsumerRecord<String, RequestFintEvent>) {
         logger.info("Received Request: {}", consumerRecord.key())

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventProducer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventProducer.kt
@@ -11,68 +11,53 @@ import no.novari.kafka.topic.name.EventTopicNameParameters
 import no.novari.kafka.topic.name.TopicNamePrefixParameters
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.time.Duration
 
 @Service
 class RequestFintEventProducer(
     parameterizedTemplateFactory: ParameterizedTemplateFactory,
-    private val eventTopicService: EventTopicService,
-    private val config: ConsumerConfiguration,
+    eventTopicService: EventTopicService,
+    private val consumerConfig: ConsumerConfiguration,
 ) {
+    private val logger = LoggerFactory.getLogger(javaClass)
     private val producer = parameterizedTemplateFactory.createTemplate(RequestFintEvent::class.java)
-    private val ensuredTopics = mutableSetOf<String>()
 
-    companion object {
-        private val logger = LoggerFactory.getLogger(RequestFintEventProducer::class.java)
-        val RETENTION_TIME: Duration = Duration.ofDays(7)
-        const val PARTITIONS = 1
-    }
-
-    fun publish(
-        resourceName: String,
-        requestFintEvent: RequestFintEvent,
-    ) {
-        val topic = ensureTopic(resourceName)
-        producer.send(
-            ParameterizedProducerRecord
-                .builder<RequestFintEvent>()
-                .key(requestFintEvent.corrId)
-                .topicNameParameters(topic)
-                .value(requestFintEvent)
-                .build(),
-        )
-    }
-
-    private fun ensureTopic(resourceName: String): EventTopicNameParameters =
-        eventTopicFor(resourceName).also { topic ->
-            if (ensuredTopics.add(topic.eventName)) {
-                logger.debug("Ensuring event topic: {}", topic.eventName)
-                eventTopicService.createOrModifyTopic(
-                    topic,
-                    EventTopicConfiguration
-                        .stepBuilder()
-                        .partitions(PARTITIONS)
-                        .retentionTime(RETENTION_TIME)
-                        .cleanupFrequency(EventCleanupFrequency.NORMAL)
-                        .build(),
-                )
-            }
-        }
-
-    private fun eventTopicFor(resourceName: String): EventTopicNameParameters =
+    private val topicNameParameters =
         EventTopicNameParameters
             .builder()
             .topicNamePrefixParameters(
                 TopicNamePrefixParameters
                     .stepBuilder()
-                    .orgId(config.orgId.asTopicSegment)
+                    .orgId(consumerConfig.orgId.asTopicSegment)
                     .domainContextApplicationDefault()
                     .build(),
-            ).eventName(eventNameFor(resourceName))
+            ).eventName("${consumerConfig.domain}-${consumerConfig.packageName}-request")
             .build()
 
-    private fun eventNameFor(resourceName: String) =
-        with(config) {
-            "$domain-$packageName-$resourceName-request"
-        }
+    init {
+        ensureTopicExists(eventTopicService)
+    }
+
+    fun publish(requestFintEvent: RequestFintEvent) {
+        logger.info("Publishing RequestFintEvent: {}", requestFintEvent.corrId)
+        producer.send(
+            ParameterizedProducerRecord
+                .builder<RequestFintEvent>()
+                .key(requestFintEvent.corrId)
+                .topicNameParameters(topicNameParameters)
+                .value(requestFintEvent)
+                .build(),
+        )
+    }
+
+    private fun ensureTopicExists(eventTopicService: EventTopicService) {
+        eventTopicService.createOrModifyTopic(
+            topicNameParameters,
+            EventTopicConfiguration
+                .stepBuilder()
+                .partitions(consumerConfig.kafka.requestPartitions)
+                .retentionTime(consumerConfig.kafka.requestRetentionTime)
+                .cleanupFrequency(EventCleanupFrequency.NORMAL)
+                .build(),
+        )
+    }
 }

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventService.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventService.kt
@@ -28,7 +28,7 @@ class RequestFintEventService(
         resourceData
             .toFintResource(resourceName)
             .toRequestFintEvent(resourceName, operationType)
-            .also { requestFintEventProducer.publish(resourceName, it) }
+            .also { requestFintEventProducer.publish(it) }
 
     fun createAndPublish(
         resourceName: String,

--- a/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventProducerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventProducerTest.kt
@@ -27,6 +27,11 @@ class RequestFintEventProducerTest {
         every { config.domain } returns "utdanning"
         every { config.packageName } returns "vurdering"
         every { config.orgId } returns OrgId.from("fintlabs.no")
+        every { config.kafka } returns
+            mockk {
+                every { requestPartitions } returns 1
+                every { requestRetentionTime } returns java.time.Duration.ofDays(7)
+            }
         every { parameterizedTemplateFactory.createTemplate(RequestFintEvent::class.java) } returns kafkaTemplate
 
         producer = RequestFintEventProducer(parameterizedTemplateFactory, eventTopicService, config)
@@ -36,44 +41,38 @@ class RequestFintEventProducerTest {
     fun `publish sends event with corrId as key`() {
         val event = RequestFintEvent().apply { corrId = "abc-123" }
 
-        producer.publish("elevfravar", event)
+        producer.publish(event)
 
         verify { kafkaTemplate.send(match<ParameterizedProducerRecord<RequestFintEvent>> { it.key == "abc-123" }) }
     }
 
     @Test
-    fun `publish builds event name from domain, package and resource`() {
+    fun `publish builds event name from domain and package`() {
         val event = RequestFintEvent().apply { corrId = "abc-123" }
 
-        producer.publish("elevfravar", event)
+        producer.publish(event)
 
         verify {
             kafkaTemplate.send(
                 match<ParameterizedProducerRecord<RequestFintEvent>> {
-                    (it.topicNameParameters as EventTopicNameParameters).eventName ==
-                        "utdanning-vurdering-elevfravar-request"
+                    (it.topicNameParameters as EventTopicNameParameters).eventName == "utdanning-vurdering-request"
                 },
             )
         }
     }
 
     @Test
-    fun `ensureTopic is only called once for the same resource`() {
-        val event = RequestFintEvent().apply { corrId = "abc-123" }
-
-        producer.publish("elevfravar", event)
-        producer.publish("elevfravar", event)
-
+    fun `ensureTopic is called once during construction`() {
         verify(exactly = 1) { eventTopicService.createOrModifyTopic(any(), any()) }
     }
 
     @Test
-    fun `ensureTopic is called separately for different resources`() {
+    fun `multiple publishes do not create additional topics`() {
         val event = RequestFintEvent().apply { corrId = "abc-123" }
 
-        producer.publish("elevfravar", event)
-        producer.publish("eksamensgruppe", event)
+        producer.publish(event)
+        producer.publish(event)
 
-        verify(exactly = 2) { eventTopicService.createOrModifyTopic(any(), any()) }
+        verify(exactly = 1) { eventTopicService.createOrModifyTopic(any(), any()) }
     }
 }

--- a/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventServiceTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventServiceTest.kt
@@ -116,7 +116,7 @@ class RequestFintEventServiceTest {
 
         val event = service.createAndPublish(resourceName, fintResource, OperationType.CREATE)
 
-        verify(exactly = 1) { producer.publish(resourceName, event) }
+        verify(exactly = 1) { producer.publish(event) }
     }
 
     @Test


### PR DESCRIPTION
Changes:
- Get resource name from kafka entity header
- Consume all entities on one topic
- Consume all events on one topic
- Produce all events on one topic