### PR TITLE
Feature/relation update entity topics

### DIFF
--- a/src/integrationTest/java/no/fintlabs/consumer/integration/AutoRelationIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/AutoRelationIT.kt
@@ -11,7 +11,11 @@ import no.fintlabs.autorelation.model.RelationOperation
 import no.fintlabs.autorelation.model.RelationUpdate
 import no.fintlabs.cache.CacheService
 import no.fintlabs.consumer.config.OrgId
-import no.fintlabs.consumer.kafka.KafkaConstants.*
+import no.fintlabs.consumer.kafka.KafkaConstants.LAST_MODIFIED
+import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
+import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_CORRELATION_ID
+import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TOTAL_SIZE
+import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TYPE
 import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
 import no.novari.fint.model.resource.FintResource
 import no.novari.fint.model.resource.Link
@@ -40,7 +44,7 @@ import org.springframework.test.context.TestPropertySource
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Duration
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -320,7 +324,7 @@ class AutoRelationIT {
                 binding = relationBinding,
                 operation = operation,
             )
-        relationUpdateProducer.publishRelationUpdate(relationUpdate, resourceName).get(10, TimeUnit.SECONDS)
+        relationUpdateProducer.publishRelationUpdate(relationUpdate, resourceName, resourceId).get(10, TimeUnit.SECONDS)
     }
 
     private fun assertLinkWithSuffixExists(

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/AutoRelationIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/AutoRelationIT.kt
@@ -11,11 +11,7 @@ import no.fintlabs.autorelation.model.RelationOperation
 import no.fintlabs.autorelation.model.RelationUpdate
 import no.fintlabs.cache.CacheService
 import no.fintlabs.consumer.config.OrgId
-import no.fintlabs.consumer.kafka.KafkaConstants.LAST_MODIFIED
-import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
-import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_CORRELATION_ID
-import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TOTAL_SIZE
-import no.fintlabs.consumer.kafka.KafkaConstants.SYNC_TYPE
+import no.fintlabs.consumer.kafka.KafkaConstants.*
 import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
 import no.novari.fint.model.resource.FintResource
 import no.novari.fint.model.resource.Link
@@ -44,20 +40,14 @@ import org.springframework.test.context.TestPropertySource
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Duration
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
-@EmbeddedKafka(
-    partitions = 1,
-    topics = [
-        "foo-org.fint-core.entity.utdanning-vurdering",
-        "foo-org.fint-core.event.relation-update",
-    ],
-)
+@EmbeddedKafka(partitions = 1)
 @ActiveProfiles("utdanning-vurdering")
 @TestPropertySource(
     properties = [
@@ -330,7 +320,7 @@ class AutoRelationIT {
                 binding = relationBinding,
                 operation = operation,
             )
-        relationUpdateProducer.publishRelationUpdate(relationUpdate).get(10, TimeUnit.SECONDS)
+        relationUpdateProducer.publishRelationUpdate(relationUpdate, resourceName).get(10, TimeUnit.SECONDS)
     }
 
     private fun assertLinkWithSuffixExists(

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/ManyToManyAutoRelationIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/ManyToManyAutoRelationIT.kt
@@ -46,13 +46,7 @@ fun constructAutorelationEntityTopic(
 ) = "${OrgId.from(org).asTopicSegment}.$domainContext.entity.$resourceName"
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
-@EmbeddedKafka(
-    partitions = 1,
-    topics = [
-        "foo-org.fint-core.entity.utdanning-elev",
-        "foo-org.fint-core.event.relation-update",
-    ],
-)
+@EmbeddedKafka(partitions = 1)
 @TestPropertySource(
     properties = [
         "spring.kafka.bootstrap-servers=\${spring.embedded.kafka.brokers}",

--- a/src/main/java/no/fintlabs/autorelation/RelationEventService.kt
+++ b/src/main/java/no/fintlabs/autorelation/RelationEventService.kt
@@ -64,7 +64,7 @@ class RelationEventService(
                 )
 
             publish(resourceName, resourceId, relationName) {
-                relationUpdateProducer.publishRelationUpdate(update)
+                relationUpdateProducer.publishRelationUpdate(update, resourceName, resourceId)
             }
         }
     }
@@ -78,7 +78,7 @@ class RelationEventService(
     ) = rules.forEach { rule ->
         publish(resourceName, resourceId) {
             rule.toRelationUpdate(resource, resourceId, operation)?.let {
-                relationUpdateProducer.publishRelationUpdate(it)
+                relationUpdateProducer.publishRelationUpdate(it, resourceName, resourceId)
             }
         }
     }

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -58,7 +58,8 @@ class RelationUpdateConsumer(
                 EntityTopicNamePatternParameters
                     .builder()
                     .topicNamePatternPrefixParameters(
-                        TopicNamePatternPrefixParameters.stepBuilder()
+                        TopicNamePatternPrefixParameters
+                            .stepBuilder()
                             .orgId(TopicNamePatternParameterPattern.exactly(consumerConfig.orgId.asTopicSegment))
                             .domainContextApplicationDefault()
                             .build(),

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -7,8 +7,9 @@ import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
-import no.novari.kafka.topic.name.EventTopicNameParameters
-import no.novari.kafka.topic.name.TopicNamePrefixParameters
+import no.novari.kafka.topic.name.EntityTopicNamePatternParameters
+import no.novari.kafka.topic.name.TopicNamePatternParameterPattern
+import no.novari.kafka.topic.name.TopicNamePatternPrefixParameters
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -35,8 +36,8 @@ class RelationUpdateConsumer(
     fun relationUpdateConsumerContainer(
         parameterizedListenerContainerFactoryService: ParameterizedListenerContainerFactoryService,
         errorHandlerFactory: ErrorHandlerFactory,
-    ): ConcurrentMessageListenerContainer<String, RelationUpdate> {
-        return parameterizedListenerContainerFactoryService
+    ): ConcurrentMessageListenerContainer<String, RelationUpdate> =
+        parameterizedListenerContainerFactoryService
             .createRecordListenerContainerFactory(
                 RelationUpdate::class.java,
                 this::consumeRecord,
@@ -54,18 +55,17 @@ class RelationUpdateConsumer(
                     ),
                 ),
             ).createContainer(
-                EventTopicNameParameters
+                EntityTopicNamePatternParameters
                     .builder()
-                    .topicNamePrefixParameters(
-                        TopicNamePrefixParameters
-                            .stepBuilder()
-                            .orgId(consumerConfig.orgId.asTopicSegment)
+                    .topicNamePatternPrefixParameters(
+                        TopicNamePatternPrefixParameters.stepBuilder()
+                            .orgId(TopicNamePatternParameterPattern.exactly(consumerConfig.orgId.asTopicSegment))
                             .domainContextApplicationDefault()
                             .build(),
-                    ).eventName("relation-update")
+                        // Makes sure we listen to component patterns such as utdanning-vurdering'-relation-update'
+                    ).resource(TopicNamePatternParameterPattern.endingWith("-relation-update"))
                     .build(),
             ).apply { consumerConfig.kafka.relationConcurrency }
-    }
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String?, RelationUpdate>) =
         consumerRecord

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateProducer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateProducer.kt
@@ -4,47 +4,81 @@ import no.fintlabs.autorelation.model.RelationUpdate
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.novari.kafka.producing.ParameterizedProducerRecord
 import no.novari.kafka.producing.ParameterizedTemplateFactory
-import no.novari.kafka.topic.EventTopicService
-import no.novari.kafka.topic.configuration.EventCleanupFrequency
-import no.novari.kafka.topic.configuration.EventTopicConfiguration
-import no.novari.kafka.topic.name.EventTopicNameParameters
+import no.novari.kafka.topic.EntityTopicService
+import no.novari.kafka.topic.configuration.EntityCleanupFrequency
+import no.novari.kafka.topic.configuration.EntityTopicConfiguration
+import no.novari.kafka.topic.name.EntityTopicNameParameters
 import no.novari.kafka.topic.name.TopicNamePrefixParameters
+import no.novari.metamodel.MetamodelService
 import org.springframework.kafka.support.SendResult
-import org.springframework.stereotype.Component
+import org.springframework.stereotype.Service
 import java.util.concurrent.CompletableFuture
 
-@Component
+@Service
 class RelationUpdateProducer(
-    eventTopicService: EventTopicService,
+    entityTopicService: EntityTopicService,
     parameterizedTemplateFactory: ParameterizedTemplateFactory,
     private val consumerConfiguration: ConsumerConfiguration,
+    metamodelService: MetamodelService,
 ) {
-    private val eventTopic = createEventTopic()
     private val entityProducer = parameterizedTemplateFactory.createTemplate(RelationUpdate::class.java)
 
     init {
-        eventTopicService.createOrModifyTopic(
-            eventTopic,
-            EventTopicConfiguration
-                .stepBuilder()
-                .partitions(consumerConfiguration.kafka.relationPartitions)
-                .retentionTime(consumerConfiguration.kafka.relationRetentionTime)
-                .cleanupFrequency(EventCleanupFrequency.NORMAL)
-                .build(),
-        )
+        // Because we are sending relation updates between components, we need to ensure all topics so its present before publishing.
+        // Therefore, its important all the configuration across deployments match the exact same relationRetentionTime.
+        metamodelService.getComponents().forEach { component ->
+            entityTopicService.createOrModifyTopic(
+                createTopicNameParameters(component.domainName, component.packageName),
+                EntityTopicConfiguration
+                    .stepBuilder()
+                    .partitions(consumerConfiguration.kafka.relationPartitions)
+                    .lastValueRetentionTime(consumerConfiguration.kafka.relationRetentionTime)
+                    .nullValueRetentionTime(consumerConfiguration.kafka.relationRetentionTime)
+                    .cleanupFrequency(EntityCleanupFrequency.FREQUENT) // Triggers compaction every 3.rd hour
+                    .build(),
+            )
+        }
     }
 
-    fun publishRelationUpdate(relationUpdate: RelationUpdate): CompletableFuture<SendResult<String, RelationUpdate>> =
-        entityProducer.send(
-            ParameterizedProducerRecord
-                .builder<RelationUpdate>()
-                .topicNameParameters(eventTopic)
-                .value(relationUpdate)
-                .build(),
-        )
+    fun publishRelationUpdate(
+        relationUpdate: RelationUpdate,
+        resourceName: String,
+    ): CompletableFuture<SendResult<String, RelationUpdate>> =
+        with(relationUpdate.targetEntity) {
+            entityProducer.send(
+                ParameterizedProducerRecord
+                    .builder<RelationUpdate>()
+                    .key(relationUpdate.toKey(resourceName))
+                    .topicNameParameters(createTopicNameParameters(domainName, packageName))
+                    .value(relationUpdate)
+                    .build(),
+            )
+        }
 
-    private fun createEventTopic() =
-        EventTopicNameParameters
+    /**
+     * Builds a unique Kafka message key for this relation update.
+     *
+     * The key uniquely identifies a single relation slot: the binding between a specific source
+     * resource instance and a specific target entity type via a specific relation. This ensures:
+     *
+     * - **Compaction correctness**: Each relation slot gets its own key, so compaction retains
+     *   the latest state per slot without overwriting unrelated relation updates from the same
+     *   source resource.
+     * - **Partition ordering**: ADD and DELETE for the same relation slot always share the same
+     *   key and are therefore routed to the same partition, guaranteeing correct ordering.
+     *
+     * Format: `{sourceResourceName}/{identifier}#{targetResource}#{relationName}`
+     * Example: `elev/abc123#elevforhold#elev`
+     *
+     * Note: [targetEntity.domainName] and [targetEntity.packageName] are intentionally omitted
+     * from the key since the topic itself already encodes that scope.
+     */
+    internal fun RelationUpdate.toKey(resourceName: String): String =
+        "$resourceName/${binding.link.href.substringAfterLast("/")}#${targetEntity.resourceName}#${binding.relationName}"
+
+
+    private fun createTopicNameParameters(domainName: String, packageName: String) =
+        EntityTopicNameParameters
             .builder()
             .topicNamePrefixParameters(
                 TopicNamePrefixParameters
@@ -52,6 +86,6 @@ class RelationUpdateProducer(
                     .orgId(consumerConfiguration.orgId.asTopicSegment)
                     .domainContextApplicationDefault()
                     .build(),
-            ).eventName("relation-update")
+            ).resourceName("$domainName-$packageName-relation-update")
             .build()
 }

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateProducer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateProducer.kt
@@ -43,12 +43,13 @@ class RelationUpdateProducer(
     fun publishRelationUpdate(
         relationUpdate: RelationUpdate,
         resourceName: String,
+        resourceId: String,
     ): CompletableFuture<SendResult<String, RelationUpdate>> =
         with(relationUpdate.targetEntity) {
             entityProducer.send(
                 ParameterizedProducerRecord
                     .builder<RelationUpdate>()
-                    .key(relationUpdate.toKey(resourceName))
+                    .key(relationUpdate.toKey(resourceName, resourceId))
                     .topicNameParameters(createTopicNameParameters(domainName, packageName))
                     .value(relationUpdate)
                     .build(),
@@ -73,19 +74,22 @@ class RelationUpdateProducer(
      * Note: [targetEntity.domainName] and [targetEntity.packageName] are intentionally omitted
      * from the key since the topic itself already encodes that scope.
      */
-    internal fun RelationUpdate.toKey(resourceName: String): String =
-        "$resourceName/${binding.link.href.substringAfterLast("/")}#${targetEntity.resourceName}#${binding.relationName}"
+    internal fun RelationUpdate.toKey(
+        resourceName: String,
+        resourceId: String,
+    ): String = "$resourceName/$resourceId#${targetEntity.resourceName}#${binding.relationName}"
 
-
-    private fun createTopicNameParameters(domainName: String, packageName: String) =
-        EntityTopicNameParameters
-            .builder()
-            .topicNamePrefixParameters(
-                TopicNamePrefixParameters
-                    .stepBuilder()
-                    .orgId(consumerConfiguration.orgId.asTopicSegment)
-                    .domainContextApplicationDefault()
-                    .build(),
-            ).resourceName("$domainName-$packageName-relation-update")
-            .build()
+    private fun createTopicNameParameters(
+        domainName: String,
+        packageName: String,
+    ) = EntityTopicNameParameters
+        .builder()
+        .topicNamePrefixParameters(
+            TopicNamePrefixParameters
+                .stepBuilder()
+                .orgId(consumerConfiguration.orgId.asTopicSegment)
+                .domainContextApplicationDefault()
+                .build(),
+        ).resourceName("$domainName-$packageName-relation-update")
+        .build()
 }


### PR DESCRIPTION
Changes:
relation update/s:
- are published on entity topic format
- topics are now split up based on component
- topics are now created on startup for every organization and component
- messages has a key, specific to that resource-id and update instance to support compaction