### PR TITLE
hotfix/configurable topic ensuring (#85)

### DIFF
--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -66,8 +66,11 @@ class RelationUpdateConsumer(
                             .domainContextApplicationDefault()
                             .build(),
                         // Makes sure we listen to component patterns such as utdanning-vurdering'-relation-update'
-                    ).resource(TopicNamePatternParameterPattern.endingWith("-relation-update"))
-                    .build(),
+                    ).resource(
+                        TopicNamePatternParameterPattern.exactly(
+                            "${consumerConfig.domain}-${consumerConfig.packageName}-relation-update",
+                        ),
+                    ).build(),
             ).apply { concurrency = consumerConfig.kafka.relationConcurrency }
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String?, RelationUpdate>) {

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateProducer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateProducer.kt
@@ -26,19 +26,21 @@ class RelationUpdateProducer(
     private val entityProducer = parameterizedTemplateFactory.createTemplate(RelationUpdate::class.java)
 
     init {
-        // Because we are sending relation updates between components, we need to ensure all topics so its present before publishing.
-        // Therefore, its important all the configuration across deployments match the exact same relationRetentionTime.
-        metamodelService.getComponents().forEach { component ->
-            entityTopicService.createOrModifyTopic(
-                createTopicNameParameters(component.domainName, component.packageName),
-                EntityTopicConfiguration
-                    .stepBuilder()
-                    .partitions(consumerConfiguration.kafka.relationPartitions)
-                    .lastValueRetentionTime(consumerConfiguration.kafka.relationRetentionTime)
-                    .nullValueRetentionTime(consumerConfiguration.kafka.relationRetentionTime)
-                    .cleanupFrequency(EntityCleanupFrequency.FREQUENT) // Triggers compaction every 3.rd hour
-                    .build(),
-            )
+        if (consumerConfiguration.kafka.ensureTopics) {
+            // Because we are sending relation updates between components, we need to ensure all topics so its present before publishing.
+            // Therefore, its important all the configuration across deployments match the exact same relationRetentionTime.
+            metamodelService.getComponents().forEach { component ->
+                entityTopicService.createOrModifyTopic(
+                    createTopicNameParameters(component.domainName, component.packageName),
+                    EntityTopicConfiguration
+                        .stepBuilder()
+                        .partitions(consumerConfiguration.kafka.relationPartitions)
+                        .lastValueRetentionTime(consumerConfiguration.kafka.relationRetentionTime)
+                        .nullValueRetentionTime(consumerConfiguration.kafka.relationRetentionTime)
+                        .cleanupFrequency(EntityCleanupFrequency.FREQUENT) // Triggers compaction every 3.rd hour
+                        .build(),
+                )
+            }
         }
     }
 

--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -58,4 +58,6 @@ data class KafkaConfiguration(
     val requestRetentionTime: Duration = Duration.ofDays(7),
     // ResponseFintEvent
     val responseConcurrency: Int = 1,
+    // Topic management
+    val ensureTopics: Boolean = true,
 )

--- a/src/test/java/no/fintlabs/autorelation/kafka/RelationUpdateProducerTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/kafka/RelationUpdateProducerTest.kt
@@ -1,0 +1,98 @@
+package no.fintlabs.autorelation.kafka
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.fintlabs.autorelation.model.RelationUpdate
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.config.KafkaConfiguration
+import no.fintlabs.consumer.config.OrgId
+import no.fintlabs.consumer.kafka.KafkaThroughputMetrics
+import no.novari.kafka.producing.ParameterizedTemplate
+import no.novari.kafka.producing.ParameterizedTemplateFactory
+import no.novari.kafka.topic.EntityTopicService
+import no.novari.kafka.topic.name.EntityTopicNameParameters
+import no.novari.metamodel.MetamodelService
+import no.novari.metamodel.model.Component
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RelationUpdateProducerTest {
+    private lateinit var entityTopicService: EntityTopicService
+    private lateinit var parameterizedTemplateFactory: ParameterizedTemplateFactory
+    private lateinit var consumerConfiguration: ConsumerConfiguration
+    private lateinit var kafkaThroughputMetrics: KafkaThroughputMetrics
+    private lateinit var metamodelService: MetamodelService
+    private lateinit var template: ParameterizedTemplate<RelationUpdate>
+
+    @BeforeEach
+    fun setUp() {
+        entityTopicService = mockk(relaxed = true)
+        parameterizedTemplateFactory = mockk()
+        consumerConfiguration = mockk()
+        kafkaThroughputMetrics = mockk(relaxed = true)
+        metamodelService = mockk()
+        template = mockk()
+
+        every { parameterizedTemplateFactory.createTemplate(RelationUpdate::class.java) } returns template
+        every { consumerConfiguration.orgId } returns OrgId.from("foo.bar")
+        every { consumerConfiguration.kafka } returns KafkaConfiguration()
+
+        val component1 =
+            mockk<Component>().also {
+                every { it.domainName } returns "utdanning"
+                every { it.packageName } returns "vurdering"
+            }
+        val component2 =
+            mockk<Component>().also {
+                every { it.domainName } returns "utdanning"
+                every { it.packageName } returns "elev"
+            }
+        every { metamodelService.getComponents() } returns listOf(component1, component2)
+    }
+
+    @Test
+    fun `when ensureTopics is true, createOrModifyTopic is called for each component`() {
+        every { consumerConfiguration.kafka } returns KafkaConfiguration(ensureTopics = true)
+
+        RelationUpdateProducer(
+            entityTopicService,
+            parameterizedTemplateFactory,
+            consumerConfiguration,
+            kafkaThroughputMetrics,
+            metamodelService,
+        )
+
+        verify(exactly = 2) { entityTopicService.createOrModifyTopic(any<EntityTopicNameParameters>(), any()) }
+    }
+
+    @Test
+    fun `when ensureTopics is false, createOrModifyTopic is never called`() {
+        every { consumerConfiguration.kafka } returns KafkaConfiguration(ensureTopics = false)
+
+        RelationUpdateProducer(
+            entityTopicService,
+            parameterizedTemplateFactory,
+            consumerConfiguration,
+            kafkaThroughputMetrics,
+            metamodelService,
+        )
+
+        verify(exactly = 0) { entityTopicService.createOrModifyTopic(any<EntityTopicNameParameters>(), any()) }
+    }
+
+    @Test
+    fun `when ensureTopics is true by default, createOrModifyTopic is called for each component`() {
+        every { consumerConfiguration.kafka } returns KafkaConfiguration()
+
+        RelationUpdateProducer(
+            entityTopicService,
+            parameterizedTemplateFactory,
+            consumerConfiguration,
+            kafkaThroughputMetrics,
+            metamodelService,
+        )
+
+        verify(exactly = 2) { entityTopicService.createOrModifyTopic(any<EntityTopicNameParameters>(), any()) }
+    }
+}


### PR DESCRIPTION
* fix: update topic pattern to use exact match for relation-update events

* feat: add `ensureTopics` property in `ConsumerConfiguration` for topic management

* feat: ensure topics creation is conditional on `ensureTopics` configuration

* test: add unit tests for `RelationUpdateProducer` to verify topic creation logic

* feat: enable topic creation by default via `ensureTopics` setting

* test: update `RelationUpdateProducerTest` to verify topic creation when `ensureTopics` is true by default