### PR TITLE
feat: Increase Kafka fetch size

### DIFF
--- a/src/integrationTest/java/no/fintlabs/consumer/kafka/IdleBetweenPollsIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/kafka/IdleBetweenPollsIT.kt
@@ -1,0 +1,181 @@
+package no.fintlabs.consumer.kafka
+
+import no.fintlabs.Application
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.novari.kafka.consuming.ErrorHandlerFactory
+import no.novari.kafka.consuming.ListenerConfiguration
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
+import no.novari.kafka.producing.ParameterizedProducerRecord
+import no.novari.kafka.producing.ParameterizedTemplateFactory
+import no.novari.kafka.topic.name.EntityTopicNameParameters
+import no.novari.kafka.topic.name.TopicNamePrefixParameters
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.kafka.test.utils.ContainerTestUtils
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@EmbeddedKafka(partitions = 1)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.bootstrap-servers=\${spring.embedded.kafka.brokers}",
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=idle-between-polls-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=foo.org",
+        "fint.consumer.org-id=foo.org",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=elev",
+        "fint.security.enabled=false",
+    ],
+)
+@Import(IdleBetweenPollsIT.TestConfig::class, KafkaTestJacksonConfig::class)
+@DirtiesContext
+class IdleBetweenPollsIT {
+    @Autowired
+    private lateinit var timingContainer: ConcurrentMessageListenerContainer<String, Any>
+
+    @Autowired
+    private lateinit var timingProbe: TimingProbe
+
+    @Autowired
+    private lateinit var parameterizedTemplateFactory: ParameterizedTemplateFactory
+
+    @Autowired
+    private lateinit var consumerConfiguration: ConsumerConfiguration
+
+    @AfterEach
+    fun tearDown() {
+        timingContainer.stop()
+        timingProbe.reset()
+    }
+
+    @Test
+    fun `idleBetweenPolls delays delivery between records across polls`() {
+        timingProbe.reset()
+        timingContainer.start()
+        ContainerTestUtils.waitForAssignment(timingContainer, 1)
+
+        val producer = parameterizedTemplateFactory.createTemplate(Any::class.java)
+        repeat(4) { index ->
+            producer
+                .send(
+                    ParameterizedProducerRecord
+                        .builder<Any>()
+                        .key("debug-${UUID.randomUUID()}")
+                        .topicNameParameters(debugTopic())
+                        .value(mapOf("index" to index))
+                        .build(),
+                ).get()
+        }
+
+        await.atMost(Duration.ofSeconds(10)).untilAsserted {
+            assertEquals(4, timingProbe.timestamps.size)
+        }
+
+        val timestamps = timingProbe.timestamps.toList()
+        val gapsMs =
+            timestamps
+                .zipWithNext()
+                .map { (previous, next) -> next - previous }
+
+        assertEquals(3, gapsMs.size)
+        assertTrue(
+            gapsMs.all { it >= 1250L },
+            "Expected all poll gaps to be at least ~1250ms with idleBetweenPolls=1350ms, but was $gapsMs",
+        )
+    }
+
+    private fun debugTopic() =
+        EntityTopicNameParameters
+            .builder()
+            .topicNamePrefixParameters(
+                TopicNamePrefixParameters
+                    .stepBuilder()
+                    .orgId(consumerConfiguration.orgId.asTopicSegment)
+                    .domainContextApplicationDefault()
+                    .build(),
+            ).resourceName("debug-idle-between-polls")
+            .build()
+
+    class TimingProbe {
+        val timestamps = CopyOnWriteArrayList<Long>()
+
+        fun recordNow() {
+            timestamps.add(System.currentTimeMillis())
+        }
+
+        fun reset() {
+            timestamps.clear()
+        }
+    }
+
+    @TestConfiguration
+    class TestConfig {
+        @Bean
+        fun timingProbe() = TimingProbe()
+
+        @Bean
+        fun timingContainer(
+            parameterizedListenerContainerFactoryService: ParameterizedListenerContainerFactoryService,
+            errorHandlerFactory: ErrorHandlerFactory,
+            consumerConfiguration: ConsumerConfiguration,
+            timingProbe: TimingProbe,
+        ): ConcurrentMessageListenerContainer<String, Any> {
+            val container =
+                parameterizedListenerContainerFactoryService
+                    .createRecordListenerContainerFactory(
+                        Any::class.java,
+                        { timingProbe.recordNow() },
+                        ListenerConfiguration
+                            .stepBuilder()
+                            .groupIdApplicationDefaultWithSuffix("-idle-between-polls-it")
+                            .maxPollRecords(1)
+                            .maxPollIntervalKafkaDefault()
+                            .continueFromPreviousOffsetOnAssignment()
+                            .build(),
+                        errorHandlerFactory.createErrorHandler(
+                            KafkaConsumerErrorHandling.createLoggingErrorHandlerConfiguration<Any>(
+                                org.slf4j.LoggerFactory.getLogger(IdleBetweenPollsIT::class.java),
+                                "idle-between-polls-it",
+                            ),
+                        ),
+                        { listenerContainer ->
+                            listenerContainer.concurrency = 1
+                            listenerContainer.containerProperties.idleBetweenPolls = 1350L
+                            listenerContainer.isAutoStartup = false
+                            listenerContainer.applyConsumerFetchSettings(consumerConfiguration.kafka)
+                        },
+                    ).createContainer(
+                        EntityTopicNameParameters
+                            .builder()
+                            .topicNamePrefixParameters(
+                                TopicNamePrefixParameters
+                                    .stepBuilder()
+                                    .orgId(consumerConfiguration.orgId.asTopicSegment)
+                                    .domainContextApplicationDefault()
+                                    .build(),
+                            ).resourceName("debug-idle-between-polls")
+                            .build(),
+                    )
+
+            container.isAutoStartup = false
+            return container
+        }
+    }
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/kafka/IdleBetweenPollsIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/kafka/IdleBetweenPollsIT.kt
@@ -84,7 +84,7 @@ class IdleBetweenPollsIT {
                 ).get()
         }
 
-        await.atMost(Duration.ofSeconds(10)).untilAsserted {
+        await.atMost(Duration.ofSeconds(20)).untilAsserted {
             assertEquals(4, timingProbe.timestamps.size)
         }
 

--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -1,0 +1,49 @@
+fint:
+  security:
+    opa:
+      enabled: false
+    exposed-endpoints:
+      - /actuator/prometheus
+      - /actuator/health
+  relation:
+    base-url: https://api.felleskomponent.no
+  consumer:
+    pod-url: http://fint-core-consumer-${fint.consumer.domain}-${fint.consumer.package}:8080
+    base-url: ${fint.relation.base-url}
+    domain: utdanning
+    package: vurdering
+    packageName: ${fint.consumer.package}
+    org-id: ${fint.org-id}
+    coreVersionHeader: 2
+    kafka:
+      fetchMinBytes: 1
+      fetchMaxWaitMs: 50
+      idleBetweenPolls: 0
+
+novari:
+  kafka:
+    topic:
+      org-id: ${fint.org-id}
+      domain-context: fint-core
+    application-id: fint-core-consumer-${fint.consumer.domain}-${fint.consumer.package}-${fint.org-id}
+
+spring:
+  threads:
+    virtual:
+      enabled: true
+  kafka:
+    consumer:
+      group-id: ${novari.kafka.application-id}
+  webflux:
+    base-path: ${fint.consumer.domain}/${fint.consumer.package}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,health
+
+logging:
+  level:
+    org.apache.kafka: WARN
+    no.novari.kafka: WARN

--- a/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
@@ -71,7 +71,10 @@ class AutoRelationEntityConsumer(
                             .build(),
                     ).resourceName("${consumerConfig.domain}-${consumerConfig.packageName}")
                     .build(),
-            ).apply { concurrency = consumerConfig.kafka.entityConcurrency }
+            ).apply {
+                concurrency = consumerConfig.kafka.entityConcurrency
+                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
+            }
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String, Any?>) {
         consumerRecord

--- a/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
@@ -4,6 +4,7 @@ import no.fintlabs.autorelation.RelationEventService
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
+import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
 import no.fintlabs.consumer.kafka.entity.extractIdentifier
 import no.fintlabs.consumer.kafka.stringValue
 import no.novari.kafka.consuming.ErrorHandlerFactory
@@ -60,6 +61,11 @@ class AutoRelationEntityConsumer(
                         CONSUMER_NAME,
                     ),
                 ),
+                { container ->
+                    container.concurrency = consumerConfig.kafka.entityConcurrency
+                    container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
+                    container.applyConsumerFetchSettings(consumerConfig.kafka)
+                },
             ).createContainer(
                 EntityTopicNameParameters
                     .builder()
@@ -71,10 +77,7 @@ class AutoRelationEntityConsumer(
                             .build(),
                     ).resourceName("${consumerConfig.domain}-${consumerConfig.packageName}")
                     .build(),
-            ).apply {
-                concurrency = consumerConfig.kafka.entityConcurrency
-                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
-            }
+            )
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String, Any?>) {
         consumerRecord

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -74,6 +74,7 @@ class RelationUpdateConsumer(
                     ).build(),
             ).apply {
                 concurrency = consumerConfig.kafka.relationConcurrency
+                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                 applyConsumerFetchSettings(consumerConfig.kafka)
             }
 

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -57,6 +57,11 @@ class RelationUpdateConsumer(
                         CONSUMER_NAME,
                     ),
                 ),
+                { container ->
+                    container.concurrency = consumerConfig.kafka.relationConcurrency
+                    container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
+                    container.applyConsumerFetchSettings(consumerConfig.kafka)
+                },
             ).createContainer(
                 EntityTopicNamePatternParameters
                     .builder()
@@ -72,11 +77,7 @@ class RelationUpdateConsumer(
                             "${consumerConfig.domain}-${consumerConfig.packageName}-relation-update",
                         ),
                     ).build(),
-            ).apply {
-                concurrency = consumerConfig.kafka.relationConcurrency
-                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
-                applyConsumerFetchSettings(consumerConfig.kafka)
-            }
+            )
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String?, RelationUpdate>) {
         val startedAt = System.nanoTime()

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -5,6 +5,7 @@ import no.fintlabs.autorelation.model.RelationUpdate
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
 import no.fintlabs.consumer.kafka.KafkaThroughputMetrics
+import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
@@ -71,7 +72,10 @@ class RelationUpdateConsumer(
                             "${consumerConfig.domain}-${consumerConfig.packageName}-relation-update",
                         ),
                     ).build(),
-            ).apply { concurrency = consumerConfig.kafka.relationConcurrency }
+            ).apply {
+                concurrency = consumerConfig.kafka.relationConcurrency
+                applyConsumerFetchSettings(consumerConfig.kafka)
+            }
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String?, RelationUpdate>) {
         val startedAt = System.nanoTime()

--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -49,6 +49,8 @@ data class KafkaConfiguration(
     val consumeLegacyResourceTopics: Boolean = false,
     val entityConcurrency: Int = 1,
     val relationEntitySeekToBeginning: Boolean = false,
+    val fetchMinBytes: Int = 65536,
+    val fetchMaxWaitMs: Int = 500,
     // RelationUpdate
     val relationConcurrency: Int = 1,
     val relationPartitions: Int = 1,

--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -51,7 +51,7 @@ data class KafkaConfiguration(
     val relationEntitySeekToBeginning: Boolean = false,
     val fetchMinBytes: Int = 65536,
     val fetchMaxWaitMs: Int = 500,
-    // RelationUpdate
+    val idleBetweenPolls: Long = 0,
     val relationConcurrency: Int = 1,
     val relationPartitions: Int = 1,
     val relationRetentionTime: Duration = Duration.ofDays(7),

--- a/src/main/java/no/fintlabs/consumer/kafka/KafkaContainerCustomizer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/KafkaContainerCustomizer.kt
@@ -1,0 +1,18 @@
+package no.fintlabs.consumer.kafka
+
+import no.fintlabs.consumer.config.KafkaConfiguration
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+
+fun <VALUE> ConcurrentMessageListenerContainer<String, VALUE>.applyConsumerFetchSettings(
+    kafkaConfiguration: KafkaConfiguration,
+) {
+    containerProperties.kafkaConsumerProperties.setProperty(
+        ConsumerConfig.FETCH_MIN_BYTES_CONFIG,
+        kafkaConfiguration.fetchMinBytes.toString(),
+    )
+    containerProperties.kafkaConsumerProperties.setProperty(
+        ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG,
+        kafkaConfiguration.fetchMaxWaitMs.toString(),
+    )
+}

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
@@ -3,17 +3,15 @@ package no.fintlabs.consumer.kafka.entity
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
+import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
 import no.fintlabs.consumer.kafka.stringValue
 import no.fintlabs.consumer.resource.ResourceConverter
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
-import no.novari.kafka.topic.name.EntityTopicNameParameters
 import no.novari.kafka.topic.name.EntityTopicNamePatternParameters
 import no.novari.kafka.topic.name.TopicNamePatternParameterPattern
-import no.novari.kafka.topic.name.TopicNamePatternParameters
 import no.novari.kafka.topic.name.TopicNamePatternPrefixParameters
-import no.novari.kafka.topic.name.TopicNamePrefixParameters
 import no.novari.metamodel.MetamodelService
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
@@ -66,7 +64,10 @@ class EntityConsumer(
                             .build(),
                     ).resource(TopicNamePatternParameterPattern.anyOf(componentTopic(), *legacyResourceTopics()))
                     .build(),
-            ).apply { concurrency = consumerConfig.kafka.entityConcurrency }
+            ).apply {
+                concurrency = consumerConfig.kafka.entityConcurrency
+                applyConsumerFetchSettings(consumerConfig.kafka)
+            }
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String, Any?>) =
         createEntityConsumerRecord(consumerRecord)

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
@@ -53,6 +53,11 @@ class EntityConsumer(
                         CONSUMER_NAME,
                     ),
                 ),
+                { container ->
+                    container.concurrency = consumerConfig.kafka.entityConcurrency
+                    container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
+                    container.applyConsumerFetchSettings(consumerConfig.kafka)
+                },
             ).createContainer(
                 EntityTopicNamePatternParameters
                     .builder()
@@ -64,11 +69,7 @@ class EntityConsumer(
                             .build(),
                     ).resource(TopicNamePatternParameterPattern.anyOf(componentTopic(), *legacyResourceTopics()))
                     .build(),
-            ).apply {
-                concurrency = consumerConfig.kafka.entityConcurrency
-                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
-                applyConsumerFetchSettings(consumerConfig.kafka)
-            }
+            )
 
     fun consumeRecord(consumerRecord: ConsumerRecord<String, Any?>) =
         createEntityConsumerRecord(consumerRecord)

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
@@ -66,6 +66,7 @@ class EntityConsumer(
                     .build(),
             ).apply {
                 concurrency = consumerConfig.kafka.entityConcurrency
+                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                 applyConsumerFetchSettings(consumerConfig.kafka)
             }
 

--- a/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
@@ -56,6 +56,7 @@ class EventResponseConsumer(
                     .build(),
             ).apply {
                 concurrency = consumerConfig.kafka.responseConcurrency
+                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                 applyConsumerFetchSettings(consumerConfig.kafka)
             }
 

--- a/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
@@ -3,6 +3,7 @@ package no.fintlabs.consumer.kafka.event
 import no.fintlabs.adapter.models.event.ResponseFintEvent
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
+import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
 import no.fintlabs.consumer.resource.event.EventStatusCache
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
@@ -53,7 +54,10 @@ class EventResponseConsumer(
                             .build(),
                     ).eventName("${consumerConfig.domain}-${consumerConfig.packageName}-response")
                     .build(),
-            ).apply { concurrency = consumerConfig.kafka.responseConcurrency }
+            ).apply {
+                concurrency = consumerConfig.kafka.responseConcurrency
+                applyConsumerFetchSettings(consumerConfig.kafka)
+            }
 
     private fun consumeRecord(consumerRecord: ConsumerRecord<String, ResponseFintEvent>) {
         logger.info("Received Response: {}", consumerRecord.value())

--- a/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
@@ -43,6 +43,11 @@ class EventResponseConsumer(
                         CONSUMER_NAME,
                     ),
                 ),
+                { container ->
+                    container.concurrency = consumerConfig.kafka.responseConcurrency
+                    container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
+                    container.applyConsumerFetchSettings(consumerConfig.kafka)
+                },
             ).createContainer(
                 EventTopicNameParameters
                     .builder()
@@ -54,11 +59,7 @@ class EventResponseConsumer(
                             .build(),
                     ).eventName("${consumerConfig.domain}-${consumerConfig.packageName}-response")
                     .build(),
-            ).apply {
-                concurrency = consumerConfig.kafka.responseConcurrency
-                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
-                applyConsumerFetchSettings(consumerConfig.kafka)
-            }
+            )
 
     private fun consumeRecord(consumerRecord: ConsumerRecord<String, ResponseFintEvent>) {
         logger.info("Received Response: {}", consumerRecord.value())

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
@@ -3,6 +3,7 @@ package no.fintlabs.consumer.kafka.event
 import no.fintlabs.adapter.models.event.RequestFintEvent
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
+import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
 import no.fintlabs.consumer.resource.event.EventStatusCache
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
@@ -58,7 +59,10 @@ class RequestFintEventConsumer(
                             .build(),
                     ).eventName("${consumerConfig.domain}-${consumerConfig.packageName}-request")
                     .build(),
-            ).apply { concurrency = consumerConfig.kafka.requestConcurrency }
+            ).apply {
+                concurrency = consumerConfig.kafka.requestConcurrency
+                applyConsumerFetchSettings(consumerConfig.kafka)
+            }
 
     private fun consumeRecord(consumerRecord: ConsumerRecord<String, RequestFintEvent>) {
         logger.info("Received Request: {}", consumerRecord.key())

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
@@ -61,6 +61,7 @@ class RequestFintEventConsumer(
                     .build(),
             ).apply {
                 concurrency = consumerConfig.kafka.requestConcurrency
+                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                 applyConsumerFetchSettings(consumerConfig.kafka)
             }
 

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
@@ -48,6 +48,11 @@ class RequestFintEventConsumer(
                         CONSUMER_NAME,
                     ),
                 ),
+                { container ->
+                    container.concurrency = consumerConfig.kafka.requestConcurrency
+                    container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
+                    container.applyConsumerFetchSettings(consumerConfig.kafka)
+                },
             ).createContainer(
                 EventTopicNameParameters
                     .builder()
@@ -59,11 +64,7 @@ class RequestFintEventConsumer(
                             .build(),
                     ).eventName("${consumerConfig.domain}-${consumerConfig.packageName}-request")
                     .build(),
-            ).apply {
-                concurrency = consumerConfig.kafka.requestConcurrency
-                containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
-                applyConsumerFetchSettings(consumerConfig.kafka)
-            }
+            )
 
     private fun consumeRecord(consumerRecord: ConsumerRecord<String, RequestFintEvent>) {
         logger.info("Received Request: {}", consumerRecord.key())

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ fint:
     coreVersionHeader: 2
     kafka:
       fetchMinBytes: 65536
-      fetchMaxWaitMs: 500
+      fetchMaxWaitMs: 10000
 
 novari:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,6 +30,10 @@ spring:
   kafka:
     consumer:
       group-id: ${novari.kafka.application-id}
+      properties:
+          fetch.min.bytes: 65536
+          fetch.max.wait.ms: 500
+
   webflux:
     base-path: ${fint.consumer.domain}/${fint.consumer.package}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,9 @@ fint:
     packageName: ${fint.consumer.package}
     org-id: ${fint.org-id}
     coreVersionHeader: 2
+    kafka:
+      fetchMinBytes: 65536
+      fetchMaxWaitMs: 500
 
 novari:
   kafka:
@@ -30,9 +33,6 @@ spring:
   kafka:
     consumer:
       group-id: ${novari.kafka.application-id}
-      properties:
-          fetch.min.bytes: 65536
-          fetch.max.wait.ms: 500
 
   webflux:
     base-path: ${fint.consumer.domain}/${fint.consumer.package}

--- a/src/test/java/no/fintlabs/consumer/kafka/entity/EntityConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/entity/EntityConsumerTest.kt
@@ -244,6 +244,7 @@ class EntityConsumerTest {
                 any<Consumer<ConsumerRecord<String, Any>>>(),
                 capture(slot),
                 any(),
+                any(),
             )
         } returns factory
         entityConsumer.resourceEntityConsumerFactory(factoryService, errorHandlerFactory)

--- a/src/test/java/no/fintlabs/consumer/kafka/entity/EntityConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/entity/EntityConsumerTest.kt
@@ -17,6 +17,7 @@ import no.novari.kafka.topic.name.TopicNamePatternParameters
 import no.novari.metamodel.MetamodelService
 import no.novari.metamodel.model.Component
 import no.novari.metamodel.model.Resource
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecord.NULL_SIZE
 import org.apache.kafka.common.header.internals.RecordHeader
@@ -25,7 +26,9 @@ import org.apache.kafka.common.record.TimestampType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.kafka.core.ConsumerFactory
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.listener.ContainerProperties
 import java.util.Optional
 import java.util.function.Consumer
 import kotlin.test.assertEquals
@@ -51,7 +54,11 @@ class EntityConsumerTest {
         factoryService = mockk()
         errorHandlerFactory = mockk(relaxed = true)
         factory = mockk()
-        container = mockk(relaxed = true)
+        container =
+            ConcurrentMessageListenerContainer<String, Any>(
+                mockk<ConsumerFactory<String, Any>>(relaxed = true),
+                ContainerProperties("test-topic"),
+            )
 
         every { consumerConfig.orgId } returns OrgId.from("foo.bar")
         every { consumerConfig.domain } returns "utdanning"
@@ -61,6 +68,7 @@ class EntityConsumerTest {
             factoryService.createRecordListenerContainerFactory(
                 any<Class<Any>>(),
                 any<Consumer<ConsumerRecord<String, Any>>>(),
+                any(),
                 any(),
                 any(),
             )
@@ -111,6 +119,43 @@ class EntityConsumerTest {
         assertTrue(resourcePattern.anyOfValues.contains("utdanning-vurdering"))
         assertTrue(resourcePattern.anyOfValues.contains("utdanning-vurdering-elevfravar"))
         assertTrue(resourcePattern.anyOfValues.contains("utdanning-vurdering-eksamenskarakter"))
+    }
+
+    @Test
+    fun `container gets fetch and idle settings from consumer configuration`() {
+        every {
+            consumerConfig.kafka
+        } returns KafkaConfiguration(fetchMinBytes = 12345, fetchMaxWaitMs = 678, idleBetweenPolls = 222)
+
+        val customizer = slot<Consumer<ConcurrentMessageListenerContainer<String, Any>>>()
+        every {
+            factoryService.createRecordListenerContainerFactory(
+                any<Class<Any>>(),
+                any<Consumer<ConsumerRecord<String, Any>>>(),
+                any(),
+                any(),
+                capture(customizer),
+            )
+        } answers {
+            customizer.captured.accept(container)
+            factory
+        }
+
+        val createdContainer = entityConsumer.resourceEntityConsumerFactory(factoryService, errorHandlerFactory)
+
+        assertEquals(222L, createdContainer.containerProperties.idleBetweenPolls)
+        assertEquals(
+            "12345",
+            createdContainer.containerProperties.kafkaConsumerProperties.getProperty(
+                ConsumerConfig.FETCH_MIN_BYTES_CONFIG,
+            ),
+        )
+        assertEquals(
+            "678",
+            createdContainer.containerProperties.kafkaConsumerProperties.getProperty(
+                ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG,
+            ),
+        )
     }
 
     @Test

--- a/src/test/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumerTest.kt
@@ -80,6 +80,7 @@ class RelationUpdateConsumerTest {
                 any<Consumer<ConsumerRecord<String, RelationUpdate>>>(),
                 capture(slot),
                 any(),
+                any(),
             )
         } returns factory
         every { factory.createContainer(any<TopicNamePatternParameters>()) } returns container

--- a/src/test/java/no/fintlabs/consumer/kafka/event/EventResponseConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/event/EventResponseConsumerTest.kt
@@ -52,6 +52,7 @@ class EventResponseConsumerTest {
                 any<Consumer<ConsumerRecord<String, ResponseFintEvent>>>(),
                 any(),
                 any(),
+                any(),
             )
         } returns factory
         every { factory.createContainer(any<TopicNameParameters>()) } returns container
@@ -78,6 +79,7 @@ class EventResponseConsumerTest {
                 any<Class<ResponseFintEvent>>(),
                 any<Consumer<ConsumerRecord<String, ResponseFintEvent>>>(),
                 capture(slot),
+                any(),
                 any(),
             )
         } returns factory

--- a/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumerTest.kt
@@ -54,6 +54,7 @@ class RequestFintEventConsumerTest {
                 any<Consumer<ConsumerRecord<String, RequestFintEvent>>>(),
                 any(),
                 any(),
+                any(),
             )
         } returns factory
         every { factory.createContainer(any<TopicNameParameters>()) } returns container
@@ -80,6 +81,7 @@ class RequestFintEventConsumerTest {
                 any<Class<RequestFintEvent>>(),
                 any<Consumer<ConsumerRecord<String, RequestFintEvent>>>(),
                 capture(slot),
+                any(),
                 any(),
             )
         } returns factory


### PR DESCRIPTION
Set fetch.min.bytes to 64 KiB and fetch.max.wait.ms to 500 ms for Kafka consumers.

Previously, consumers used the default configuration (fetch.min.bytes=1), which causes the broker to return data as soon as any message is available. In low-throughput scenarios, this leads to very frequent fetch requests with small payloads, increasing CPU usage on the brokers.

With this change:

* The broker will wait until at least 64 KiB of data is available before responding, or up to 500 ms if the threshold is not reached.
* This reduces the number of fetch requests and improves batching efficiency.
* CPU overhead on Kafka brokers is expected to decrease due to fewer, larger responses.

Impact:

* In low-traffic topics: slightly increased latency (up to ~500 ms) but significantly fewer fetch requests.
* In high-throughput periods (e.g. full dumps): no meaningful delay, as the threshold is reached quickly and batching improves throughput.

This is a trade-off favoring throughput and resource efficiency over minimal latency, which is acceptable for our use cases.