### PR TITLE
refactor/buffer link without retrying

### DIFF
--- a/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
+++ b/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
@@ -38,7 +38,7 @@ class AutoRelationService(
                     linkService.mapLinks(relationUpdate.targetEntity.resourceName, resourceCopy)
                     putInCache(relationUpdate, id, resourceCopy)
                 } else {
-                    relationUpdate.applyOrBufferRelation(id)
+                    relationUpdate.bufferRelation(id)
                 }
             }
         }
@@ -111,12 +111,7 @@ class AutoRelationService(
         .takeRelations(resourceName, resourceId, relationName)
         .let { linksToAttach -> addUniqueLinks(relationName, linksToAttach) }
 
-    private fun RelationUpdate.applyOrBufferRelation(id: String) {
-        updatePendingCache(id)
-        retryIfResourceArrived(id)
-    }
-
-    private fun RelationUpdate.updatePendingCache(id: String) =
+    private fun RelationUpdate.bufferRelation(id: String) =
         with(binding) {
             when (operation) {
                 RelationOperation.ADD -> {
@@ -139,15 +134,6 @@ class AutoRelationService(
                 }
             }
         }
-
-    private fun RelationUpdate.retryIfResourceArrived(id: String) =
-        getResourceFromCache(targetEntity.resourceName, id)
-            ?.deepCopy(objectMapper, getResourceClass())
-            ?.run {
-                applyUpdate(this@retryIfResourceArrived)
-                linkService.mapLinks(targetEntity.resourceName, this)
-                putInCache(this@retryIfResourceArrived, id, this)
-            }
 
     private fun getResourceFromCache(
         resource: String,

--- a/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
@@ -133,29 +133,6 @@ class AutoRelationServiceTest {
     }
 
     @Nested
-    inner class RaceConditionScenarios {
-        @Test
-        fun `should apply update if resource arrives during buffering (Double Check)`() {
-            val lateArrivingResource = createElevFravar()
-            val targetId = relationUpdate.targetIds.first()
-
-            every {
-                cacheService.getCache(relationUpdate.targetEntity.resourceName).get(targetId)
-            } returnsMany listOf(null, lateArrivingResource)
-
-            service.applyOrBufferUpdate(relationUpdate)
-
-            verify(exactly = 1) {
-                unresolvedRelationCache.registerRelation(any(), targetId, any(), any(), any())
-            }
-
-            verify(exactly = 1) {
-                linkService.mapLinks(relationUpdate.targetEntity.resourceName, any())
-            }
-        }
-    }
-
-    @Nested
     inner class ReconcileLinksScenarios {
         @Test
         fun `should handle new resource (no old resource) without pruning`() {


### PR DESCRIPTION
Since we are now locking resourceName + resourceId, we can now remove unnecessary code that covers a potential race-condition.