### PR TITLE
feat: unique group ID suffix for listener configurations

### DIFF
--- a/src/integrationTest/java/no/fintlabs/consumer/kafka/SeekToBeginningIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/kafka/SeekToBeginningIT.kt
@@ -1,0 +1,211 @@
+package no.fintlabs.consumer.kafka
+
+import no.fintlabs.Application
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.novari.kafka.consuming.ErrorHandlerFactory
+import no.novari.kafka.consuming.ListenerConfiguration
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
+import no.novari.kafka.producing.ParameterizedProducerRecord
+import no.novari.kafka.producing.ParameterizedTemplateFactory
+import no.novari.kafka.topic.name.EntityTopicNameParameters
+import no.novari.kafka.topic.name.TopicNamePrefixParameters
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.kafka.test.utils.ContainerTestUtils
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+
+/**
+ * Proves that each pod gets a unique group ID and reads all historical messages from the beginning,
+ * regardless of what other pods have already consumed.
+ *
+ * The positive test shows that two consumers with different UUID-based group IDs both independently
+ * read all messages from offset 0.
+ *
+ * The negative test shows the problem that would occur without unique group IDs: a second consumer
+ * reusing the same group ID skips messages already committed by the first consumer, and would
+ * therefore start with an incomplete in-memory cache.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@EmbeddedKafka(partitions = 1)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.bootstrap-servers=\${spring.embedded.kafka.brokers}",
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=seek-to-beginning-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=foo.org",
+        "fint.consumer.org-id=foo.org",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=elev",
+        "fint.security.enabled=false",
+    ],
+)
+@Import(KafkaTestJacksonConfig::class)
+@DirtiesContext
+class SeekToBeginningIT {
+    companion object {
+        private val logger = LoggerFactory.getLogger(SeekToBeginningIT::class.java)
+        private const val MESSAGE_COUNT = 10
+    }
+
+    @Autowired
+    private lateinit var parameterizedListenerContainerFactoryService: ParameterizedListenerContainerFactoryService
+
+    @Autowired
+    private lateinit var errorHandlerFactory: ErrorHandlerFactory
+
+    @Autowired
+    private lateinit var parameterizedTemplateFactory: ParameterizedTemplateFactory
+
+    @Autowired
+    private lateinit var consumerConfiguration: ConsumerConfiguration
+
+    private val activeContainers = mutableListOf<ConcurrentMessageListenerContainer<String, Any>>()
+
+    @AfterEach
+    fun tearDown() {
+        activeContainers.forEach { it.stop() }
+        activeContainers.clear()
+    }
+
+    @Test
+    fun `each pod with unique group id independently reads all historical messages from the beginning`() {
+        publishMessages("seek-positive", MESSAGE_COUNT)
+
+        // Pod 1: unique group id + seekToBeginning → reads all messages from offset 0
+        val pod1Count = AtomicInteger(0)
+        val pod1 = createContainer("seek-positive", uniqueGroup = true) { pod1Count.incrementAndGet() }
+        pod1.start()
+        ContainerTestUtils.waitForAssignment(pod1, 1)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            assertEquals(MESSAGE_COUNT, pod1Count.get(), "Pod 1 should read all historical messages")
+        }
+        pod1.stop()
+
+        // Pod 2: different UUID group → also reads ALL messages from offset 0, not from where pod 1 left off
+        val pod2Count = AtomicInteger(0)
+        val pod2 = createContainer("seek-positive", uniqueGroup = true) { pod2Count.incrementAndGet() }
+        pod2.start()
+        ContainerTestUtils.waitForAssignment(pod2, 1)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            assertEquals(MESSAGE_COUNT, pod2Count.get(), "Pod 2 should also read all historical messages independently")
+        }
+        pod2.stop()
+    }
+
+    @Test
+    fun `negative - pod reusing a shared group id skips messages already committed by a previous pod`() {
+        publishMessages("seek-negative", MESSAGE_COUNT)
+
+        // First consumer with a FIXED group id reads and commits all messages
+        val firstCount = AtomicInteger(0)
+        val first = createContainer("seek-negative", uniqueGroup = false) { firstCount.incrementAndGet() }
+        first.start()
+        ContainerTestUtils.waitForAssignment(first, 1)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            assertEquals(MESSAGE_COUNT, firstCount.get())
+        }
+        first.stop() // graceful stop commits offsets
+
+        // Second consumer with the SAME group id: offsets are already committed, so it sees no messages
+        val secondCount = AtomicInteger(0)
+        val second = createContainer("seek-negative", uniqueGroup = false) { secondCount.incrementAndGet() }
+        second.start()
+        ContainerTestUtils.waitForAssignment(second, 1)
+
+        Thread.sleep(2_000)
+
+        assertEquals(
+            0,
+            secondCount.get(),
+            "A pod reusing the same group id should not re-read committed messages — " +
+                "it would start with an incomplete cache",
+        )
+        second.stop()
+    }
+
+    private fun publishMessages(
+        topicSuffix: String,
+        count: Int,
+    ) {
+        val producer = parameterizedTemplateFactory.createTemplate(Any::class.java)
+        repeat(count) { index ->
+            producer
+                .send(
+                    ParameterizedProducerRecord
+                        .builder<Any>()
+                        .key("msg-$index")
+                        .topicNameParameters(topicNameParameters(topicSuffix))
+                        .value(mapOf("index" to index))
+                        .build(),
+                ).get()
+        }
+    }
+
+    private fun createContainer(
+        topicSuffix: String,
+        uniqueGroup: Boolean,
+        onRecord: () -> Unit,
+    ): ConcurrentMessageListenerContainer<String, Any> {
+        val listenerConfig =
+            ListenerConfiguration
+                .stepBuilder()
+                .let {
+                    if (uniqueGroup) {
+                        it.groupIdApplicationDefaultWithUniqueSuffix()
+                    } else {
+                        it.groupIdApplicationDefaultWithSuffix("-shared-$topicSuffix")
+                    }
+                }.maxPollRecordsKafkaDefault()
+                .maxPollIntervalKafkaDefault()
+                .let {
+                    if (uniqueGroup) {
+                        it.seekToBeginningOnAssignment()
+                    } else {
+                        it.continueFromPreviousOffsetOnAssignment()
+                    }
+                }.build()
+
+        return parameterizedListenerContainerFactoryService
+            .createRecordListenerContainerFactory(
+                Any::class.java,
+                { onRecord() },
+                listenerConfig,
+                errorHandlerFactory.createErrorHandler(
+                    KafkaConsumerErrorHandling.createLoggingErrorHandlerConfiguration<Any>(logger, topicSuffix),
+                ),
+                { it.isAutoStartup = false },
+            ).createContainer(topicNameParameters(topicSuffix))
+            .apply {
+                isAutoStartup = false
+                activeContainers.add(this)
+            }
+    }
+
+    private fun topicNameParameters(topicSuffix: String) =
+        EntityTopicNameParameters
+            .builder()
+            .topicNamePrefixParameters(
+                TopicNamePrefixParameters
+                    .stepBuilder()
+                    .orgId(consumerConfiguration.orgId.asTopicSegment)
+                    .domainContextApplicationDefault()
+                    .build(),
+            ).resourceName(topicSuffix)
+            .build()
+}

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -45,7 +45,7 @@ class RelationUpdateConsumer(
                 this::consumeRecord,
                 ListenerConfiguration
                     .stepBuilder()
-                    .groupIdApplicationDefault()
+                    .groupIdApplicationDefaultWithUniqueSuffix()
                     .maxPollRecordsKafkaDefault()
                     .maxPollIntervalKafkaDefault()
                     .seekToBeginningOnAssignment()

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
@@ -44,7 +44,7 @@ class EntityConsumer(
                 this::consumeRecord,
                 ListenerConfiguration
                     .stepBuilder()
-                    .groupIdApplicationDefault()
+                    .groupIdApplicationDefaultWithUniqueSuffix()
                     .maxPollRecordsKafkaDefault()
                     .maxPollIntervalKafkaDefault()
                     .seekToBeginningOnAssignment()

--- a/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
@@ -31,7 +31,7 @@ class EventResponseConsumer(
                 this::consumeRecord,
                 ListenerConfiguration
                     .stepBuilder()
-                    .groupIdApplicationDefault()
+                    .groupIdApplicationDefaultWithUniqueSuffix()
                     .maxPollRecordsKafkaDefault()
                     .maxPollIntervalKafkaDefault()
                     .seekToBeginningOnAssignment()

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
@@ -36,7 +36,7 @@ class RequestFintEventConsumer(
                 this::consumeRecord,
                 ListenerConfiguration
                     .stepBuilder()
-                    .groupIdApplicationDefault()
+                    .groupIdApplicationDefaultWithUniqueSuffix()
                     .maxPollRecordsKafkaDefault()
                     .maxPollIntervalKafkaDefault()
                     .seekToBeginningOnAssignment()

--- a/src/test/java/no/fintlabs/consumer/kafka/entity/EntityConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/entity/EntityConsumerTest.kt
@@ -3,6 +3,7 @@ package no.fintlabs.consumer.kafka.entity
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.config.KafkaConfiguration
 import no.fintlabs.consumer.config.OrgId
@@ -10,6 +11,7 @@ import no.fintlabs.consumer.kafka.KafkaConstants.LAST_MODIFIED
 import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
 import no.fintlabs.consumer.resource.ResourceConverter
 import no.novari.kafka.consuming.ErrorHandlerFactory
+import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactory
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
 import no.novari.kafka.topic.name.EntityTopicNamePatternParameters
@@ -19,14 +21,18 @@ import no.novari.metamodel.model.Component
 import no.novari.metamodel.model.Resource
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.ConsumerRecord.NULL_SIZE
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.internals.RecordHeader
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.apache.kafka.common.record.TimestampType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.listener.ConsumerSeekAware
 import java.util.Optional
+import java.util.UUID
 import java.util.function.Consumer
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -172,6 +178,33 @@ class EntityConsumerTest {
         )
 
         assertEquals("elevfravar", captured.captured.resourceName)
+    }
+
+    @Test
+    fun `listener configuration seeks to beginning on partition assignment`() {
+        val config = captureListenerConfig()
+        val callback = mockk<ConsumerSeekAware.ConsumerSeekCallback>(relaxed = true)
+        val partition = TopicPartition("test-topic", 0)
+
+        assertTrue(config.onPartitionsAssigned.isPresent)
+        config.onPartitionsAssigned.get().accept(mapOf(partition to 0L), callback)
+
+        verify { callback.seekToBeginning(setOf(partition)) }
+    }
+
+    private fun captureListenerConfig(): ListenerConfiguration {
+        every { consumerConfig.kafka } returns KafkaConfiguration()
+        val slot = slot<ListenerConfiguration>()
+        every {
+            factoryService.createRecordListenerContainerFactory(
+                any<Class<Any>>(),
+                any<Consumer<ConsumerRecord<String, Any>>>(),
+                capture(slot),
+                any(),
+            )
+        } returns factory
+        entityConsumer.resourceEntityConsumerFactory(factoryService, errorHandlerFactory)
+        return slot.captured
     }
 
     private fun createConsumerRecord(

--- a/src/test/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumerTest.kt
@@ -2,16 +2,31 @@ package no.fintlabs.consumer.kafka.entity
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import no.fintlabs.autorelation.AutoRelationService
 import no.fintlabs.autorelation.kafka.RelationUpdateConsumer
 import no.fintlabs.autorelation.model.RelationUpdate
 import no.fintlabs.autorelation.model.createEntityDescriptor
 import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.config.KafkaConfiguration
+import no.fintlabs.consumer.config.OrgId
 import no.fintlabs.consumer.kafka.KafkaThroughputMetrics
+import no.novari.kafka.consuming.ErrorHandlerFactory
+import no.novari.kafka.consuming.ListenerConfiguration
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactory
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
+import no.novari.kafka.topic.name.TopicNamePatternParameters
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.listener.ConsumerSeekAware
+import java.util.UUID
+import java.util.function.Consumer
+import kotlin.test.assertTrue
 
 class RelationUpdateConsumerTest {
     private lateinit var autoRelationService: AutoRelationService
@@ -33,6 +48,44 @@ class RelationUpdateConsumerTest {
 
         kafkaThroughputMetrics = mockk(relaxed = true)
         relationUpdateConsumer = RelationUpdateConsumer(autoRelationService, consumerConfig, kafkaThroughputMetrics)
+    }
+
+    @Test
+    fun `listener configuration seeks to beginning on partition assignment`() {
+        val config = captureListenerConfig()
+        val callback = mockk<ConsumerSeekAware.ConsumerSeekCallback>(relaxed = true)
+        val partition = TopicPartition("test-topic", 0)
+
+        assertTrue(config.onPartitionsAssigned.isPresent)
+        config.onPartitionsAssigned.get().accept(mapOf(partition to 0L), callback)
+
+        verify { callback.seekToBeginning(setOf(partition)) }
+    }
+
+    private fun captureListenerConfig(): ListenerConfiguration {
+        val factoryService = mockk<ParameterizedListenerContainerFactoryService>()
+        val errorHandlerFactory = mockk<ErrorHandlerFactory>(relaxed = true)
+        val factory = mockk<ParameterizedListenerContainerFactory<RelationUpdate>>()
+        val container = mockk<ConcurrentMessageListenerContainer<String, RelationUpdate>>(relaxed = true)
+
+        every { consumerConfig.orgId } returns OrgId.from("foo.bar")
+        every { consumerConfig.domain } returns "utdanning"
+        every { consumerConfig.packageName } returns "vurdering"
+        every { consumerConfig.kafka } returns KafkaConfiguration()
+
+        val slot = slot<ListenerConfiguration>()
+        every {
+            factoryService.createRecordListenerContainerFactory(
+                any<Class<RelationUpdate>>(),
+                any<Consumer<ConsumerRecord<String, RelationUpdate>>>(),
+                capture(slot),
+                any(),
+            )
+        } returns factory
+        every { factory.createContainer(any<TopicNamePatternParameters>()) } returns container
+
+        relationUpdateConsumer.relationUpdateConsumerContainer(factoryService, errorHandlerFactory)
+        return slot.captured
     }
 
     @Test

--- a/src/test/java/no/fintlabs/consumer/kafka/event/EventResponseConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/event/EventResponseConsumerTest.kt
@@ -1,0 +1,87 @@
+package no.fintlabs.consumer.kafka.event
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.fintlabs.adapter.models.event.ResponseFintEvent
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.config.KafkaConfiguration
+import no.fintlabs.consumer.config.OrgId
+import no.fintlabs.consumer.resource.event.EventStatusCache
+import no.novari.kafka.consuming.ErrorHandlerFactory
+import no.novari.kafka.consuming.ListenerConfiguration
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactory
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
+import no.novari.kafka.topic.name.TopicNameParameters
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.listener.ConsumerSeekAware
+import java.util.function.Consumer
+import kotlin.test.assertTrue
+
+class EventResponseConsumerTest {
+    private lateinit var consumerConfig: ConsumerConfiguration
+    private lateinit var eventStatusCache: EventStatusCache
+    private lateinit var factoryService: ParameterizedListenerContainerFactoryService
+    private lateinit var errorHandlerFactory: ErrorHandlerFactory
+    private lateinit var factory: ParameterizedListenerContainerFactory<ResponseFintEvent>
+    private lateinit var container: ConcurrentMessageListenerContainer<String, ResponseFintEvent>
+    private lateinit var eventResponseConsumer: EventResponseConsumer
+
+    @BeforeEach
+    fun setUp() {
+        consumerConfig = mockk()
+        eventStatusCache = mockk(relaxed = true)
+        factoryService = mockk()
+        errorHandlerFactory = mockk(relaxed = true)
+        factory = mockk()
+        container = mockk(relaxed = true)
+
+        every { consumerConfig.orgId } returns OrgId.from("foo.bar")
+        every { consumerConfig.domain } returns "utdanning"
+        every { consumerConfig.packageName } returns "vurdering"
+        every { consumerConfig.kafka } returns KafkaConfiguration()
+
+        every {
+            factoryService.createRecordListenerContainerFactory(
+                any<Class<ResponseFintEvent>>(),
+                any<Consumer<ConsumerRecord<String, ResponseFintEvent>>>(),
+                any(),
+                any(),
+            )
+        } returns factory
+        every { factory.createContainer(any<TopicNameParameters>()) } returns container
+
+        eventResponseConsumer = EventResponseConsumer(consumerConfig, eventStatusCache)
+    }
+
+    @Test
+    fun `listener configuration seeks to beginning on partition assignment`() {
+        val config = captureListenerConfig()
+        val callback = mockk<ConsumerSeekAware.ConsumerSeekCallback>(relaxed = true)
+        val partition = TopicPartition("test-topic", 0)
+
+        assertTrue(config.onPartitionsAssigned.isPresent)
+        config.onPartitionsAssigned.get().accept(mapOf(partition to 0L), callback)
+
+        verify { callback.seekToBeginning(setOf(partition)) }
+    }
+
+    private fun captureListenerConfig(): ListenerConfiguration {
+        val slot = slot<ListenerConfiguration>()
+        every {
+            factoryService.createRecordListenerContainerFactory(
+                any<Class<ResponseFintEvent>>(),
+                any<Consumer<ConsumerRecord<String, ResponseFintEvent>>>(),
+                capture(slot),
+                any(),
+            )
+        } returns factory
+        eventResponseConsumer.responseFintEventContainerListener(factoryService, errorHandlerFactory)
+        return slot.captured
+    }
+}

--- a/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumerTest.kt
@@ -1,0 +1,89 @@
+package no.fintlabs.consumer.kafka.event
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import no.fintlabs.adapter.models.event.RequestFintEvent
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.config.KafkaConfiguration
+import no.fintlabs.consumer.config.OrgId
+import no.fintlabs.consumer.resource.event.EventStatusCache
+import no.novari.kafka.consuming.ErrorHandlerFactory
+import no.novari.kafka.consuming.ListenerConfiguration
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactory
+import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
+import no.novari.kafka.topic.name.TopicNameParameters
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.listener.ConsumerSeekAware
+import java.util.UUID
+import java.util.function.Consumer
+import kotlin.test.assertTrue
+
+class RequestFintEventConsumerTest {
+    private lateinit var consumerConfig: ConsumerConfiguration
+    private lateinit var eventStatusCache: EventStatusCache
+    private lateinit var factoryService: ParameterizedListenerContainerFactoryService
+    private lateinit var errorHandlerFactory: ErrorHandlerFactory
+    private lateinit var factory: ParameterizedListenerContainerFactory<RequestFintEvent>
+    private lateinit var container: ConcurrentMessageListenerContainer<String, RequestFintEvent>
+    private lateinit var requestFintEventConsumer: RequestFintEventConsumer
+
+    @BeforeEach
+    fun setUp() {
+        consumerConfig = mockk()
+        eventStatusCache = mockk(relaxed = true)
+        factoryService = mockk()
+        errorHandlerFactory = mockk(relaxed = true)
+        factory = mockk()
+        container = mockk(relaxed = true)
+
+        every { consumerConfig.orgId } returns OrgId.from("foo.bar")
+        every { consumerConfig.domain } returns "utdanning"
+        every { consumerConfig.packageName } returns "vurdering"
+        every { consumerConfig.kafka } returns KafkaConfiguration()
+
+        every {
+            factoryService.createRecordListenerContainerFactory(
+                any<Class<RequestFintEvent>>(),
+                any<Consumer<ConsumerRecord<String, RequestFintEvent>>>(),
+                any(),
+                any(),
+            )
+        } returns factory
+        every { factory.createContainer(any<TopicNameParameters>()) } returns container
+
+        requestFintEventConsumer = RequestFintEventConsumer(consumerConfig, eventStatusCache)
+    }
+
+    @Test
+    fun `listener configuration seeks to beginning on partition assignment`() {
+        val config = captureListenerConfig()
+        val callback = mockk<ConsumerSeekAware.ConsumerSeekCallback>(relaxed = true)
+        val partition = TopicPartition("test-topic", 0)
+
+        assertTrue(config.onPartitionsAssigned.isPresent)
+        config.onPartitionsAssigned.get().accept(mapOf(partition to 0L), callback)
+
+        verify { callback.seekToBeginning(setOf(partition)) }
+    }
+
+    private fun captureListenerConfig(): ListenerConfiguration {
+        val slot = slot<ListenerConfiguration>()
+        every {
+            factoryService.createRecordListenerContainerFactory(
+                any<Class<RequestFintEvent>>(),
+                any<Consumer<ConsumerRecord<String, RequestFintEvent>>>(),
+                capture(slot),
+                any(),
+            )
+        } returns factory
+        requestFintEventConsumer.requestFintEventRequestListenerContainer(factoryService, errorHandlerFactory)
+        return slot.captured
+    }
+}


### PR DESCRIPTION
Changes to use groupIdApplicationDefaultWithUniqueSuffix() when configuring kafka listeners. This ensures that it reads from start of topic. Adds tests to show that it works.