### PR TITLE
test: add Testcontainers Kafka harness and autorelation checklist

### DIFF
--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -38,9 +38,9 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 ## §4 Kafka mechanics
 
 - [x] Compaction on relation-update topic retains only the latest message per key — `CompactionBehaviourIT`
-- [x] ADD / DELETE with the same Kafka key collide — demonstrates the ~99% production loss bug — `CompactionBehaviourIT`
-- [ ] `FintCache.put()` rejects writes with older timestamps
-- [ ] `UnresolvedRelationCache` evicts buffered entries after TTL
+- [x] ADD / DELETE with the same Kafka key collide on the topic (Kafka-level proof, not a loss claim on its own) — `CompactionBehaviourIT`
+- [x] `FintCache.put()` rejects writes with older timestamps — `FintCacheTest` (`AutoRelationService.putInCache` dodges rejection via `maxOf(relationUpdate.timestamp, cache.lastUpdatedByResourceId(id))`; `EntityProcessingService.addToCache` uses the raw record timestamp and *can* silently drop out-of-order writes)
+- [x] `UnresolvedRelationCache` evicts buffered entries after TTL — `UnresolvedRelationCacheTest`
 
 ## §5 Full sync behaviour
 
@@ -74,7 +74,7 @@ Places where back-links could plausibly go missing. Not claims — hypotheses to
 
 3. **`UnresolvedRelationCache` TTL expiry** — a buffered relation update whose target entity never arrives within TTL is evicted and lost.
 
-4. **`FintCache.put()` timestamp rejection** — a relation-update write with a timestamp older than the cached entity's `lastUpdatedBy` is silently rejected.
+4. **`FintCache.put()` timestamp rejection on entity writes** — `AutoRelationService.putInCache` is protected by `maxOf(relationUpdate.timestamp, cache.lastUpdatedByResourceId(id))`, so relation-update-driven writes are safe. **But `EntityProcessingService.addToCache` uses the raw Kafka record timestamp**: if a freshly-reconciled entity arrives with a timestamp older than what is already cached (e.g. out-of-order replay, seek-to-beginning reprocessing), the write is silently rejected and the reconciled links in that copy never reach the cache.
 
 5. **`AutoRelationEntityConsumer` uses `continueFromPreviousOffset`** — on restart it does not re-publish ADDs for entities already in the entity topic, so any ADDs lost on the relation-update topic are not replenished until the next adapter-driven republish.
 

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -1,0 +1,85 @@
+# Autorelation Test Checklist
+
+Goal: 100% accuracy for auto-relation back-linking. This checklist tracks which scenarios have dedicated integration test coverage. Tick a box when an IT exists and passes.
+
+Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
+
+## §1 Cardinality / structural rules
+
+- [x] 1:M within-component — `OneToManyIT.WithinComponent`
+- [x] 1:M cross-component, source side publishes — `OneToManyIT.CrossComponent`
+- [ ] 1:M cross-component, target receives back-link (two Spring contexts)
+- [x] M:M within-component: add, prune, non-source guard, preserve — `ManyToManyIT`
+- [ ] M:M cross-component, target receives
+- [ ] Shared (`felles`) resource (e.g. Person) → target in another component
+- [ ] Shared-to-shared (e.g. Person ↔ Kontaktperson)
+- [x] 1:1 and M:1 correctly skipped (no rule generated) — `RelationRuleValidationIT`
+
+## §2 Lifecycle transitions
+
+- [x] Entity-first: relation update applied on arrival — `AutoRelationIT`
+- [x] Relation-update-first: buffered, applied when entity arrives — `AutoRelationIT`
+- [x] Pruning when source drops a link — `OneToManyIT`, `ManyToManyIT`
+- [x] Duplicate ADD is idempotent — `AutoRelationIT`
+- [ ] Multiple target IDs on one M:M source (all get back-links)
+- [ ] Move link: Target-A → Target-B (A loses, B gains)
+- [ ] Entity tombstone → DELETE published for all its relations
+- [ ] Cache eviction after full sync → DELETE published
+- [ ] Duplicate DELETE / DELETE-before-ADD ordering
+- [ ] Late ADD with older timestamp than buffered DELETE
+
+## §3 Restart / replay
+
+- [ ] `EntityConsumer` seek-to-beginning rebuilds cache correctly after restart
+- [ ] `RelationUpdateConsumer` seek-to-beginning replays buffered updates after restart
+- [ ] `AutoRelationEntityConsumer` continue-from-offset does NOT re-publish ADDs on restart
+- [ ] Restart with unresolved-relation buffer still populated drains correctly
+
+## §4 Kafka mechanics
+
+- [x] Compaction on relation-update topic retains only the latest message per key — `CompactionBehaviourIT`
+- [x] ADD / DELETE with the same Kafka key collide — demonstrates the ~99% production loss bug — `CompactionBehaviourIT`
+- [ ] `FintCache.put()` rejects writes with older timestamps
+- [ ] `UnresolvedRelationCache` evicts buffered entries after TTL
+
+## §5 Full sync behaviour
+
+- [ ] Full sync evicts stale entries → DELETE published for evictees
+- [ ] Concurrent full syncs (`ConcurrentFullSync` state) handled safely
+- [ ] Full sync with in-flight relation updates arriving mid-sync
+- [ ] Full sync followed by DELTA sync
+
+## §6 Cross-service (two consumers on shared broker)
+
+- [ ] Service A produces entity → Service B applies back-link
+- [ ] Service B restarts, replays relation-update topic, rebuilds correctly
+- [ ] Service A evicts stale entity → Service B drops back-link on DELETE
+- [ ] A + B interleaved traffic under sustained load
+
+---
+
+## Test harness
+
+- [x] Testcontainers Kafka smoke test — `TestcontainersKafkaSmokeIT`, `KafkaTestcontainersSupport`
+
+---
+
+## Candidate loss scenarios to investigate
+
+Places where back-links could plausibly go missing. Not claims — hypotheses to verify with targeted tests.
+
+1. **Race between AutoRelationEntityConsumer (ADD) and EntityConsumer prune (DELETE)** — both consume the same entity record under different consumer groups, so publication order of ADD and DELETE to the relation-update topic is non-deterministic. A DELETE-then-ADD ordering is harmless, but ADD-then-DELETE compacts to DELETE-only.
+
+2. **Restart between a pruning DELETE and the next full-sync ADD** — if a consumer restarts in this window and the relation-update topic has been compacted, targets that were in the pre-DELETE ADD but not in the DELETE's `targetIds` temporarily lose back-links until the next full sync.
+
+3. **`UnresolvedRelationCache` TTL expiry** — a buffered relation update whose target entity never arrives within TTL is evicted and lost.
+
+4. **`FintCache.put()` timestamp rejection** — a relation-update write with a timestamp older than the cached entity's `lastUpdatedBy` is silently rejected.
+
+5. **`AutoRelationEntityConsumer` uses `continueFromPreviousOffset`** — on restart it does not re-publish ADDs for entities already in the entity topic, so any ADDs lost on the relation-update topic are not replenished until the next adapter-driven republish.
+
+6. **Full-sync cache eviction race** — `CacheEvictionService` evicts stale entities after a full sync and publishes DELETEs. A relation update arriving for the target at the same moment may be rejected or buffered in a way that loses the back-link.
+
+7. **Concurrent full syncs** (`ConcurrentFullSync` state) — overlapping full syncs can disagree on which entries are stale; the losing sync's evictions/DELETEs may misrepresent ground truth.
+
+8. **Adapter re-publish without back-links + safety-net failure** — `reconcileLinks` preserves inverse links on re-arrival, but the safety-net filter removes managed relation names. If the classification of "managed" vs "inverse" is wrong for a rule, back-links are dropped on every re-publish.

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     testImplementation 'org.awaitility:awaitility-kotlin:4.3.0'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/integrationTest/java/no/fintlabs/config/KafkaTestcontainersSupport.kt
+++ b/src/integrationTest/java/no/fintlabs/config/KafkaTestcontainersSupport.kt
@@ -1,0 +1,117 @@
+package no.fintlabs.config
+
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.admin.NewTopic
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.kafka.KafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Shared base class for integration tests that need a real Kafka broker via Testcontainers.
+ *
+ * The broker is started once per JVM (static init on the companion object) and reused across
+ * every subclass, so spinning up new tests stays cheap. Each subclass is responsible for
+ * pre-creating the topics it needs — production Kafka does not auto-create topics, so tests
+ * that want to mirror production must create them explicitly before the Spring context boots.
+ *
+ * The broker is configured for aggressive log compaction so that compaction-dependent tests
+ * can observe cleaned segments within a few seconds.
+ *
+ * The recommended pattern is to call [createComponentTopics] from the subclass's own
+ * companion-object init block, which runs after this class's companion init but before
+ * Spring starts wiring any consumers:
+ *
+ * ```
+ * class MyKafkaIT : KafkaTestcontainersSupport() {
+ *     companion object { init { createComponentTopics("utdanning", "vurdering") } }
+ * }
+ * ```
+ */
+abstract class KafkaTestcontainersSupport {
+    companion object {
+        @JvmStatic
+        val KAFKA: KafkaContainer =
+            KafkaContainer(DockerImageName.parse("apache/kafka:3.8.0"))
+                // Aggressive log cleaner so compaction-dependent tests don't wait minutes.
+                .withEnv("KAFKA_LOG_CLEANER_ENABLE", "true")
+                .withEnv("KAFKA_LOG_CLEANER_MIN_CLEANABLE_RATIO", "0.01")
+                .withEnv("KAFKA_LOG_CLEANER_BACKOFF_MS", "200")
+                .withEnv("KAFKA_LOG_CLEANER_CHECK_INTERVAL_MS", "200")
+                .also { it.start() }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerKafkaProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.kafka.bootstrap-servers") { KAFKA.bootstrapServers }
+        }
+
+        /**
+         * Creates the four topics a consumer component expects at startup:
+         *  - `{orgId}.{domainContext}.entity.{domain}-{package}`
+         *  - `{orgId}.{domainContext}.entity.{domain}-{package}-relation-update`
+         *  - `{orgId}.{domainContext}.event.{domain}-{package}-request`
+         *  - `{orgId}.{domainContext}.event.{domain}-{package}-response`
+         *
+         * [orgIdSegment] is the topic-segment form (dots replaced with dashes), e.g. `fintlabs-no`.
+         */
+        fun createComponentTopics(
+            domain: String,
+            packageName: String,
+            orgIdSegment: String = "fintlabs-no",
+            domainContext: String = "fint-core",
+            partitions: Int = 1,
+            configs: Map<String, String> = emptyMap(),
+        ) {
+            val component = "$domain-$packageName"
+            val names =
+                listOf(
+                    "$orgIdSegment.$domainContext.entity.$component",
+                    "$orgIdSegment.$domainContext.entity.$component-relation-update",
+                    "$orgIdSegment.$domainContext.event.$component-request",
+                    "$orgIdSegment.$domainContext.event.$component-response",
+                )
+            createTopics(names, partitions, configs)
+        }
+
+        fun createTopics(
+            names: List<String>,
+            partitions: Int = 1,
+            configs: Map<String, String> = emptyMap(),
+        ) {
+            val newTopics =
+                names.map { name ->
+                    NewTopic(name, partitions, 1.toShort()).configs(configs)
+                }
+            adminClient().use { admin -> admin.createTopics(newTopics).all().get() }
+        }
+
+        /**
+         * Creates a log-compacted topic. Segment and compaction settings are tuned so that
+         * records become eligible for cleaning within roughly one second after a segment rolls.
+         * Callers still need to emit enough records (or enough bytes) to roll the active segment,
+         * since Kafka never compacts the active segment.
+         */
+        fun createCompactedTopic(
+            name: String,
+            partitions: Int = 1,
+            additionalConfigs: Map<String, String> = emptyMap(),
+        ) {
+            val configs =
+                mapOf(
+                    "cleanup.policy" to "compact",
+                    "min.cleanable.dirty.ratio" to "0.01",
+                    "segment.ms" to "200",
+                    "segment.bytes" to "1024",
+                    "min.compaction.lag.ms" to "0",
+                    "max.compaction.lag.ms" to "500",
+                    "delete.retention.ms" to "500",
+                ) + additionalConfigs
+            createTopics(listOf(name), partitions, configs)
+        }
+
+        fun adminClient(): AdminClient =
+            AdminClient.create(mapOf(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG to KAFKA.bootstrapServers))
+    }
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/TestcontainersKafkaSmokeIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/TestcontainersKafkaSmokeIT.kt
@@ -1,0 +1,44 @@
+package no.fintlabs.consumer.integration
+
+import no.fintlabs.Application
+import no.fintlabs.config.KafkaTestcontainersSupport
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * Smoke test verifying the Spring context starts against a Testcontainers Kafka broker
+ * with the required topics pre-created. Mirrors production behaviour (no auto-topic creation).
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ActiveProfiles("utdanning-vurdering")
+@TestPropertySource(
+    properties = [
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=testcontainers-smoke-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=vurdering",
+        "fint.consumer.autorelation.enabled=true",
+        "fint.security.enabled=false",
+    ],
+)
+@DirtiesContext
+class TestcontainersKafkaSmokeIT : KafkaTestcontainersSupport() {
+    companion object {
+        init {
+            createComponentTopics(domain = "utdanning", packageName = "vurdering")
+        }
+    }
+
+    @Test
+    fun `context starts with pre-created topics`() {
+        // Reaching this point means the Spring context booted successfully against
+        // the Testcontainers Kafka broker with the four required topics in place.
+    }
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/autorelation/CompactionBehaviourIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/autorelation/CompactionBehaviourIT.kt
@@ -1,0 +1,133 @@
+package no.fintlabs.consumer.integration.autorelation
+
+import no.fintlabs.config.KafkaTestcontainersSupport
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.Properties
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies raw Kafka log-compaction behaviour on a compacted topic configured like the
+ * production relation-update topic. These tests do not boot Spring — they prove the
+ * broker-level invariant (latest message per key wins) and demonstrate the ADD/DELETE
+ * key-collision that is the suspected source of the ~99% relation-update loss in production.
+ */
+class CompactionBehaviourIT : KafkaTestcontainersSupport() {
+    @Test
+    fun `compaction retains only the latest message per key`() {
+        val topic = "compaction-baseline-${UUID.randomUUID()}"
+        createCompactedTopic(topic)
+
+        createProducer().use { producer ->
+            producer.send(ProducerRecord(topic, "target-key", "v1")).get()
+            producer.send(ProducerRecord(topic, "target-key", "v2")).get()
+            producer.send(ProducerRecord(topic, "target-key", "v3")).get()
+            // Push bytes so the active segment rolls — the active segment is never compacted.
+            producePadding(producer, topic)
+        }
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            val values =
+                consumeAllFromBeginning(topic)
+                    .filter { (k, _) -> k == "target-key" }
+                    .map { (_, v) -> v }
+            assertEquals(1, values.size, "Expected one record for 'target-key' after compaction, got: $values")
+            assertEquals("v3", values.single())
+        }
+    }
+
+    @Test
+    fun `ADD and DELETE with the same key collide after compaction`() {
+        val topic = "compaction-collision-${UUID.randomUUID()}"
+        createCompactedTopic(topic)
+
+        // Mirrors the production key format:
+        // {sourceResource}/{sourceId}#{targetResource}#{inverseRelation}
+        val key = "kontaktlarergruppe/gruppe-1#undervisningsforhold#kontaktlarergruppe"
+
+        createProducer().use { producer ->
+            // AutoRelationEntityConsumer path: ADD back-link to all linked undervisningsforhold.
+            producer.send(ProducerRecord(topic, key, "ADD targetIds=[u1,u2,u3]")).get()
+            // EntityConsumer prune path: DELETE back-link on a dropped target — same key.
+            producer.send(ProducerRecord(topic, key, "DELETE targetIds=[u3]")).get()
+            producePadding(producer, topic)
+        }
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            val collided =
+                consumeAllFromBeginning(topic)
+                    .filter { (k, _) -> k == key }
+                    .map { (_, v) -> v }
+            assertEquals(
+                1,
+                collided.size,
+                "ADD and DELETE share the same key; after compaction only one may remain. Got: $collided",
+            )
+            assertTrue(
+                collided.single().startsWith("DELETE"),
+                "Latest wins — DELETE was produced after ADD. Got: ${collided.single()}",
+            )
+        }
+    }
+
+    private fun producePadding(
+        producer: KafkaProducer<String, String>,
+        topic: String,
+        records: Int = 30,
+        valueSize: Int = 200,
+    ) {
+        val padding = "x".repeat(valueSize)
+        repeat(records) { i ->
+            producer.send(ProducerRecord(topic, "padding-$i", padding)).get()
+        }
+    }
+
+    private fun createProducer(): KafkaProducer<String, String> {
+        val props =
+            Properties().apply {
+                put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.bootstrapServers)
+                put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java.name)
+                put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java.name)
+                put(ProducerConfig.ACKS_CONFIG, "all")
+            }
+        return KafkaProducer(props)
+    }
+
+    private fun consumeAllFromBeginning(topic: String): List<Pair<String, String>> {
+        val props =
+            Properties().apply {
+                put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.bootstrapServers)
+                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
+                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.name)
+                put(ConsumerConfig.GROUP_ID_CONFIG, "compaction-verify-${UUID.randomUUID()}")
+                put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+            }
+        KafkaConsumer<String, String>(props).use { consumer ->
+            consumer.subscribe(listOf(topic))
+            val records = mutableListOf<Pair<String, String>>()
+            val deadline = System.currentTimeMillis() + 2000
+            var idleLoops = 0
+            while (System.currentTimeMillis() < deadline && idleLoops < 3) {
+                val batch = consumer.poll(Duration.ofMillis(300))
+                if (batch.isEmpty) {
+                    idleLoops++
+                } else {
+                    idleLoops = 0
+                    batch.forEach { records.add(it.key() to it.value()) }
+                }
+            }
+            return records
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Testcontainers-based Kafka harness (`KafkaTestcontainersSupport`) so integration tests can run against a real broker with deterministic control over topic configuration (compaction, segment rolling, etc.) — scenarios that embedded Kafka cannot simulate reliably.
- Ships one working smoke/compaction IT (`CompactionBehaviourIT`, `TestcontainersKafkaSmokeIT`) that proves the harness starts cleanly and that log compaction on a compacted topic behaves as expected.
- Introduces `AUTORELATION_CHECKLIST.md` — a living document tracking autorelation scenario coverage; §4 items already covered by existing unit tests are ticked off.

## Dependency order

**This is PR 1 of 3 stacked PRs — merge this first.**

1. **This PR** → `develop` (harness foundation)
2. `test/autorelation-integration-coverage` → this branch (integration tests built on the harness)
3. `feat/autorelation-silent-loss-metrics` → PR 2's branch (silent-loss instrumentation)

## Test plan

- [ ] `./gradlew integrationTest --tests "no.fintlabs.consumer.integration.TestcontainersKafkaSmokeIT"` passes
- [ ] `./gradlew integrationTest --tests "no.fintlabs.consumer.integration.autorelation.CompactionBehaviourIT"` passes
- [ ] `./gradlew check` passes (ktlint + existing suites)
- [ ] Docker Desktop running on the review machine (required for Testcontainers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)