### PR TITLE
test: add autorelation integration coverage (§2, §3, §6, B1)

### DIFF
--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -52,7 +52,7 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 
 ## §6 Cross-service (two consumers on shared broker)
 
-- [ ] Service A produces entity → Service B applies back-link
+- [x] Service A produces entity → Service B applies back-link — `CrossServiceBackLinkIT`
 - [ ] Service B restarts, replays relation-update topic, rebuilds correctly
 - [ ] Service A evicts stale entity → Service B drops back-link on DELETE
 - [ ] A + B interleaved traffic under sustained load

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -65,6 +65,11 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 
 ---
 
+## Confirmed bugs
+
+**B1 — Stale-timestamp buffer loss** (reproduced by `StaleBufferLossIT`).
+An ADD on the relation-update topic whose `timestamp` is older than `UnresolvedRelationCache.ttl` (default 30 days) and whose target is not yet cached is silently lost. Caffeine's `expireAfterCreate` returns a negative duration → clamped to 0 → the buffer entry is evicted before it can be drained. When the target later arrives, `applyPendingLinks` finds nothing and the back-link is never applied. Reachable in production when (a) a buffered ADD is replayed after a consumer restart once the message is older than TTL, or (b) a target takes longer than TTL to appear on its entity topic. Consistent with the missing_back_link class of production defects (~0.14% of links). Fix candidates: use `Instant.now()` as `createdAt` for TTL math, drop the `createdAt` field entirely and rely on Caffeine's insertion time, or dead-letter stale ADDs instead of buffering them.
+
 ## Candidate loss scenarios to investigate
 
 Places where back-links could plausibly go missing. Not claims — hypotheses to verify with targeted tests.

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -21,17 +21,18 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 - [x] Relation-update-first: buffered, applied when entity arrives — `AutoRelationIT`
 - [x] Pruning when source drops a link — `OneToManyIT`, `ManyToManyIT`
 - [x] Duplicate ADD is idempotent — `AutoRelationIT`
-- [ ] Multiple target IDs on one M:M source (all get back-links)
+- [x] Multiple target IDs on one M:M source (all get back-links) — `ManyToManyIT` (3 targets)
+- [x] DELETE-before-ADD ordering (buffer scenario) — `AutoRelationIT` (`cancels pending add when a matching delete arrives first`)
 - [ ] Move link: Target-A → Target-B (A loses, B gains)
 - [ ] Entity tombstone → DELETE published for all its relations
 - [ ] Cache eviction after full sync → DELETE published
-- [ ] Duplicate DELETE / DELETE-before-ADD ordering
+- [ ] Duplicate DELETE (idempotency)
 - [ ] Late ADD with older timestamp than buffered DELETE
 
 ## §3 Restart / replay
 
-- [ ] `EntityConsumer` seek-to-beginning rebuilds cache correctly after restart
-- [ ] `RelationUpdateConsumer` seek-to-beginning replays buffered updates after restart
+- [x] `EntityConsumer` seek-to-beginning rebuilds cache correctly after restart — `EntityConsumerRestartIT`
+- [x] Cold restart: cache + back-links rebuilt via entity + relation-update topic replay — `ColdRestartIT`
 - [ ] `AutoRelationEntityConsumer` continue-from-offset does NOT re-publish ADDs on restart
 - [ ] Restart with unresolved-relation buffer still populated drains correctly
 

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -54,7 +54,7 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 
 - [x] Service A produces entity → Service B applies back-link — `CrossServiceBackLinkIT`
 - [x] Service B restarts, replays relation-update topic, rebuilds correctly — `CrossServiceRestartIT`
-- [ ] Service A evicts stale entity → Service B drops back-link on DELETE
+- [x] Service A evicts stale entity → Service B drops back-link on DELETE — `CrossServiceEvictionIT`
 - [ ] A + B interleaved traffic under sustained load
 
 ---

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -55,7 +55,7 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 - [x] Service A produces entity → Service B applies back-link — `CrossServiceBackLinkIT`
 - [x] Service B restarts, replays relation-update topic, rebuilds correctly — `CrossServiceRestartIT`
 - [x] Service A evicts stale entity → Service B drops back-link on DELETE — `CrossServiceEvictionIT`
-- [ ] A + B interleaved traffic under sustained load
+- [x] A + B interleaved traffic under sustained load — `CrossServiceLoadIT` (50 interleaved pairs)
 
 ---
 

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -23,7 +23,7 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 - [x] Duplicate ADD is idempotent — `AutoRelationIT`
 - [x] Multiple target IDs on one M:M source (all get back-links) — `ManyToManyIT` (3 targets)
 - [x] DELETE-before-ADD ordering (buffer scenario) — `AutoRelationIT` (`cancels pending add when a matching delete arrives first`)
-- [ ] Move link: Target-A → Target-B (A loses, B gains)
+- [x] Move link: Target-A → Target-B (A loses, B gains) — `OneToManyIT.WithinComponent.moving elev link from A to B ...`
 - [ ] Entity tombstone → DELETE published for all its relations
 - [ ] Cache eviction after full sync → DELETE published
 - [ ] Duplicate DELETE (idempotency)
@@ -84,3 +84,5 @@ Places where back-links could plausibly go missing. Not claims — hypotheses to
 7. **Concurrent full syncs** (`ConcurrentFullSync` state) — overlapping full syncs can disagree on which entries are stale; the losing sync's evictions/DELETEs may misrepresent ground truth.
 
 8. **Adapter re-publish without back-links + safety-net failure** — `reconcileLinks` preserves inverse links on re-arrival, but the safety-net filter removes managed relation names. If the classification of "managed" vs "inverse" is wrong for a rule, back-links are dropped on every re-publish.
+
+9. **Adapter publishes each entity as its own `FULL` sync with `totalSize=1`** — `SyncTrackerService` completes a full sync on every message and `CacheEvictionService` evicts all entities not present in that sync. Everything except the just-arrived record gets evicted, and eviction tombstones trigger DELETEs on the relation-update topic. If the adapter uses `SyncType.FULL` with wrong `totalSize` or fresh `corrId` per record, this would look like massive, systematic relation-update loss — worth checking a production sync trace for adapter behaviour.

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -53,7 +53,7 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 ## §6 Cross-service (two consumers on shared broker)
 
 - [x] Service A produces entity → Service B applies back-link — `CrossServiceBackLinkIT`
-- [ ] Service B restarts, replays relation-update topic, rebuilds correctly
+- [x] Service B restarts, replays relation-update topic, rebuilds correctly — `CrossServiceRestartIT`
 - [ ] Service A evicts stale entity → Service B drops back-link on DELETE
 - [ ] A + B interleaved traffic under sustained load
 

--- a/src/integrationTest/java/no/fintlabs/config/KafkaTestcontainersSupport.kt
+++ b/src/integrationTest/java/no/fintlabs/config/KafkaTestcontainersSupport.kt
@@ -3,10 +3,12 @@ package no.fintlabs.config
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.AdminClientConfig
 import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.common.errors.TopicExistsException
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.kafka.KafkaContainer
 import org.testcontainers.utility.DockerImageName
+import java.util.concurrent.ExecutionException
 
 /**
  * Shared base class for integration tests that need a real Kafka broker via Testcontainers.
@@ -84,7 +86,16 @@ abstract class KafkaTestcontainersSupport {
                 names.map { name ->
                     NewTopic(name, partitions, 1.toShort()).configs(configs)
                 }
-            adminClient().use { admin -> admin.createTopics(newTopics).all().get() }
+            adminClient().use { admin ->
+                newTopics.forEach { newTopic ->
+                    try {
+                        admin.createTopics(listOf(newTopic)).all().get()
+                    } catch (e: ExecutionException) {
+                        if (e.cause !is TopicExistsException) throw e
+                        // Idempotent: another IT class already created this topic on the shared broker.
+                    }
+                }
+            }
         }
 
         /**

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/autorelation/OneToManyIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/autorelation/OneToManyIT.kt
@@ -24,6 +24,7 @@ import org.springframework.test.context.TestPropertySource
 import java.time.Clock
 import java.time.Duration
 import java.util.UUID
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -120,6 +121,56 @@ class OneToManyIT {
                 assertTrue(
                     links.any { it.href.equals(expectedBackLinkHref, ignoreCase = true) },
                     "Expected back-link '$expectedBackLinkHref'. Found: ${links.map { it.href }}",
+                )
+            }
+        }
+
+        @Test
+        fun `moving elev link from A to B removes back-link from A and adds it to B`() {
+            val elevA = "elev-a-${UUID.randomUUID()}"
+            val elevB = "elev-b-${UUID.randomUUID()}"
+            val movedElevforholdId = "elevforhold-move-${UUID.randomUUID()}"
+            val expectedBackLink =
+                "https://test.felleskomponent.no/utdanning/elev/elevforhold/systemId/$movedElevforholdId"
+
+            // Publish both Elev under the same correlation ID so SyncTrackerService treats
+            // them as one FULL sync of size 2. Publishing them as separate size-1 syncs would
+            // complete the first sync after Elev-B arrives and evict Elev-A.
+            val elevSyncCorrId = UUID.randomUUID().toString()
+            sendEntityRecord(createElev(elevA), "elev", elevSyncCorrId, totalSize = 2)
+            sendEntityRecord(createElev(elevB), "elev", elevSyncCorrId, totalSize = 2)
+
+            sendEntityRecord(
+                createElevforhold(movedElevforholdId).apply {
+                    addElev(Link.with("systemId/$elevA"))
+                },
+                "elevforhold",
+            )
+
+            await.atMost(Duration.ofSeconds(10)).untilAsserted {
+                val linksA = cacheService.getCache("elev").get(elevA)?.links?.get("elevforhold")
+                assertTrue(
+                    linksA?.any { it.href.equals(expectedBackLink, ignoreCase = true) } == true,
+                    "elev-A should gain the back-link before the move",
+                )
+            }
+
+            sendEntityRecord(
+                createElevforhold(movedElevforholdId).apply {
+                    addElev(Link.with("systemId/$elevB"))
+                },
+                "elevforhold",
+            )
+
+            await.atMost(Duration.ofSeconds(15)).untilAsserted {
+                val linksA = cacheService.getCache("elev").get(elevA)?.links?.get("elevforhold")
+                val stillOnA = linksA?.any { it.href.equals(expectedBackLink, ignoreCase = true) } == true
+                assertFalse(stillOnA, "elev-A should lose the back-link after the move (pruned)")
+
+                val linksB = cacheService.getCache("elev").get(elevB)?.links?.get("elevforhold")
+                assertTrue(
+                    linksB?.any { it.href.equals(expectedBackLink, ignoreCase = true) } == true,
+                    "elev-B should gain the back-link after the move",
                 )
             }
         }

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/autorelation/StaleBufferLossIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/autorelation/StaleBufferLossIT.kt
@@ -1,0 +1,150 @@
+package no.fintlabs.consumer.integration.autorelation
+
+import no.fintlabs.Application
+import no.fintlabs.adapter.models.sync.SyncType
+import no.fintlabs.autorelation.buffer.UnresolvedRelationCache
+import no.fintlabs.autorelation.kafka.RelationUpdateProducer
+import no.fintlabs.autorelation.model.EntityDescriptor
+import no.fintlabs.autorelation.model.RelationBinding
+import no.fintlabs.autorelation.model.RelationOperation
+import no.fintlabs.autorelation.model.RelationUpdate
+import no.fintlabs.cache.CacheService
+import no.fintlabs.config.KafkaTestcontainersSupport
+import no.fintlabs.consumer.kafka.KafkaTestJacksonConfig
+import no.fintlabs.utils.EntityProducer
+import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
+import no.novari.fint.model.resource.Link
+import no.novari.fint.model.resource.utdanning.vurdering.ElevfravarResource
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Reproduces the suspected production loss path:
+ *
+ * 1. Source entity publishes a RelationUpdate (ADD) whose `timestamp` is already older
+ *    than `UnresolvedRelationCache` TTL.
+ * 2. `RelationUpdateConsumer` tries to buffer the ADD because the target is not yet cached.
+ * 3. Caffeine's `expireAfterCreate` computes `remaining = ttl - (now - createdAt)` — negative
+ *    for our stale timestamp — and the buffer entry is evicted before it can be drained.
+ * 4. Target entity arrives. `reconcileLinks.applyPendingLinks` finds an empty buffer.
+ * 5. Back-link never materialises.
+ *
+ * This path is reachable in production when a long-dormant ADD (surviving on the compacted
+ * relation-update topic) is replayed after a consumer restart, or whenever a target takes
+ * longer than TTL to arrive on its entity topic.
+ *
+ * TTL is set to 2 seconds via `fint.consumer.autorelation.buffer.ttl=PT2S` so the test can
+ * deterministically manufacture a stale timestamp.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ActiveProfiles("utdanning-vurdering")
+@Import(KafkaTestJacksonConfig::class)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=stale-buffer-loss-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=vurdering",
+        "fint.consumer.autorelation.enabled=true",
+        "fint.consumer.autorelation.buffer.ttl=PT2S",
+        "fint.security.enabled=false",
+    ],
+)
+@DirtiesContext
+class StaleBufferLossIT : KafkaTestcontainersSupport() {
+    companion object {
+        init {
+            createComponentTopics(domain = "utdanning", packageName = "vurdering")
+        }
+    }
+
+    @Autowired
+    lateinit var entityProducer: EntityProducer
+
+    @Autowired
+    lateinit var relationUpdateProducer: RelationUpdateProducer
+
+    @Autowired
+    lateinit var cacheService: CacheService
+
+    @Autowired
+    lateinit var unresolvedRelationCache: UnresolvedRelationCache
+
+    @Test
+    fun `stale RelationUpdate buffered with expired TTL loses its link when target arrives`() {
+        val targetResource = "elevfravar"
+        val targetId = "stale-${UUID.randomUUID()}"
+        val relationName = "fravarsregistrering"
+        val sourceResource = "fravarsregistrering"
+        val sourceId = "source-${UUID.randomUUID()}"
+        val linkHref = "https://test.felleskomponent.no/utdanning/vurdering/fravarsregistrering/systemId/$sourceId"
+
+        val staleTimestamp = System.currentTimeMillis() - Duration.ofSeconds(30).toMillis()
+        val stalePayload =
+            RelationUpdate(
+                targetEntity = EntityDescriptor("utdanning", "vurdering", targetResource),
+                targetIds = listOf(targetId),
+                binding = RelationBinding(relationName, Link.with(linkHref)),
+                operation = RelationOperation.ADD,
+                timestamp = staleTimestamp,
+            )
+
+        relationUpdateProducer
+            .publishRelationUpdate(stalePayload, sourceResource, sourceId)
+            .get(10, TimeUnit.SECONDS)
+
+        // Give the RelationUpdateConsumer time to process the ADD and the stillborn
+        // buffer entry time to be evicted by Caffeine.
+        await.atMost(Duration.ofSeconds(10)).pollDelay(Duration.ofSeconds(3)).untilAsserted {
+            unresolvedRelationCache.cleanUp()
+            assertNull(
+                unresolvedRelationCache
+                    .takeRelations(targetResource, targetId, relationName)
+                    .takeIf { it.isNotEmpty() },
+                "Stale buffer entry should have been evicted; otherwise the TTL math is different than expected",
+            )
+        }
+
+        entityProducer
+            .publish(
+                targetResource,
+                ElevfravarResource().apply {
+                    systemId = Identifikator().apply { identifikatorverdi = targetId }
+                },
+                targetId,
+                SyncType.DELTA,
+                UUID.randomUUID().toString(),
+                1,
+            ).get(10, TimeUnit.SECONDS)
+
+        await.atMost(Duration.ofSeconds(15)).untilAsserted {
+            assertNotNull(cacheService.getCache(targetResource).get(targetId), "target should be cached")
+        }
+
+        // Wait a bit longer in case something eventually applies; then assert the back-link is absent.
+        Thread.sleep(2_000)
+        val target = cacheService.getCache(targetResource).get(targetId)
+        val backLinks = target?.links?.get(relationName)
+        val hasLink = backLinks?.any { it.href.equals(linkHref, ignoreCase = true) } == true
+        assertFalse(
+            hasLink,
+            "Expected back-link to be LOST due to stale-buffer bug, but it was present: ${backLinks?.map { it.href }}",
+        )
+    }
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/crossservice/CrossServiceBackLinkIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/crossservice/CrossServiceBackLinkIT.kt
@@ -1,0 +1,164 @@
+package no.fintlabs.consumer.integration.crossservice
+
+import no.fintlabs.Application
+import no.fintlabs.adapter.models.sync.SyncType
+import no.fintlabs.cache.CacheService
+import no.fintlabs.config.KafkaTestcontainersSupport
+import no.fintlabs.consumer.kafka.KafkaTestJacksonConfig
+import no.fintlabs.utils.EntityProducer
+import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
+import no.novari.fint.model.resource.Link
+import no.novari.fint.model.resource.utdanning.elev.ElevforholdResource
+import no.novari.fint.model.resource.utdanning.utdanningsprogram.SkoleResource
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertNotNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.Banner
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertTrue
+
+/**
+ * §6.1 — Cross-service back-link flow with two independent Spring contexts sharing one
+ * Testcontainers Kafka broker.
+ *
+ * Service A (utdanning-elev) is the @SpringBootTest context. It publishes Elevforhold with
+ * a `skole` link; its `AutoRelationEntityConsumer` then publishes an ADD to the
+ * `utdanning-utdanningsprogram-relation-update` topic because Skole lives in a different
+ * component.
+ *
+ * Service B (utdanning-utdanningsprogram) is started programmatically via
+ * `SpringApplicationBuilder.run(...)` with CLI args — CLI args take higher precedence than
+ * `application.yaml`, so this reliably reconfigures the second context's domain/package.
+ * Service B's `RelationUpdateConsumer` listens on the utdanningsprogram relation-update topic
+ * and applies the back-link to its own Skole cache.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ActiveProfiles("utdanning-elev")
+@Import(KafkaTestJacksonConfig::class)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=cross-service-a-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=elev",
+        "fint.consumer.autorelation.enabled=true",
+        "fint.security.enabled=false",
+    ],
+)
+@DirtiesContext
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CrossServiceBackLinkIT : KafkaTestcontainersSupport() {
+    companion object {
+        init {
+            createComponentTopics(domain = "utdanning", packageName = "elev")
+            createComponentTopics(domain = "utdanning", packageName = "utdanningsprogram")
+        }
+    }
+
+    @Autowired
+    lateinit var serviceAProducer: EntityProducer
+
+    private lateinit var serviceBContext: ConfigurableApplicationContext
+    private lateinit var serviceBCache: CacheService
+
+    @BeforeAll
+    fun startServiceB() {
+        serviceBContext =
+            SpringApplicationBuilder(Application::class.java)
+                .bannerMode(Banner.Mode.OFF)
+                .run(
+                    "--spring.kafka.bootstrap-servers=${KAFKA.bootstrapServers}",
+                    "--spring.kafka.consumer.auto-offset-reset=earliest",
+                    "--spring.kafka.consumer.group-id=cross-service-b-${UUID.randomUUID()}",
+                    "--novari.kafka.default-replicas=1",
+                    "--fint.relation.base-url=https://test.felleskomponent.no",
+                    "--fint.org-id=fintlabs.no",
+                    "--fint.consumer.org-id=fintlabs.no",
+                    "--fint.consumer.domain=utdanning",
+                    "--fint.consumer.package=utdanningsprogram",
+                    "--fint.consumer.base-url=https://test.felleskomponent.no",
+                    "--fint.consumer.pod-url=http://service-b-test-pod",
+                    "--fint.consumer.autorelation.enabled=true",
+                    "--fint.security.enabled=false",
+                    "--server.port=0",
+                )
+        serviceBCache = serviceBContext.getBean(CacheService::class.java)
+    }
+
+    @AfterAll
+    fun stopServiceB() {
+        if (::serviceBContext.isInitialized) {
+            serviceBContext.close()
+        }
+    }
+
+    @Test
+    fun `Service A publishes Elevforhold, Service B receives back-link on Skole`() {
+        val skoleId = "cross-skole-${UUID.randomUUID()}"
+        val elevforholdId = "cross-elevforhold-${UUID.randomUUID()}"
+        val expectedBackLink =
+            "https://test.felleskomponent.no/utdanning/elev/elevforhold/systemId/$elevforholdId"
+
+        serviceAProducer
+            .publish(
+                "skole",
+                SkoleResource().apply {
+                    systemId = Identifikator().apply { identifikatorverdi = skoleId }
+                },
+                skoleId,
+                SyncType.DELTA,
+                UUID.randomUUID().toString(),
+                1,
+                domainName = "utdanning",
+                packageName = "utdanningsprogram",
+            ).get(10, TimeUnit.SECONDS)
+
+        await.atMost(Duration.ofSeconds(15)).untilAsserted {
+            assertNotNull(
+                serviceBCache.getCache("skole").get(skoleId),
+                "Service B should cache Skole $skoleId from the shared entity topic",
+            )
+        }
+
+        serviceAProducer
+            .publish(
+                "elevforhold",
+                ElevforholdResource().apply {
+                    systemId = Identifikator().apply { identifikatorverdi = elevforholdId }
+                    addSkole(Link.with("systemId/$skoleId"))
+                },
+                elevforholdId,
+                SyncType.DELTA,
+                UUID.randomUUID().toString(),
+                1,
+            ).get(10, TimeUnit.SECONDS)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            val skole = serviceBCache.getCache("skole").get(skoleId)
+            assertNotNull(skole, "Skole should still be cached on Service B")
+            val backLinks = skole.links["elevforhold"]
+            assertNotNull(backLinks, "Skole should gain an 'elevforhold' back-link from the cross-service relation update")
+            assertTrue(
+                backLinks.any { it.href.equals(expectedBackLink, ignoreCase = true) },
+                "Expected back-link $expectedBackLink. Got: ${backLinks.map { it.href }}",
+            )
+        }
+    }
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/crossservice/CrossServiceEvictionIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/crossservice/CrossServiceEvictionIT.kt
@@ -1,0 +1,177 @@
+package no.fintlabs.consumer.integration.crossservice
+
+import no.fintlabs.Application
+import no.fintlabs.adapter.models.sync.SyncType
+import no.fintlabs.cache.CacheEvictionService
+import no.fintlabs.cache.CacheService
+import no.fintlabs.config.KafkaTestcontainersSupport
+import no.fintlabs.consumer.kafka.KafkaTestJacksonConfig
+import no.fintlabs.utils.EntityProducer
+import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
+import no.novari.fint.model.resource.Link
+import no.novari.fint.model.resource.utdanning.elev.ElevforholdResource
+import no.novari.fint.model.resource.utdanning.utdanningsprogram.SkoleResource
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertNotNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.Banner
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * §6.3 — Evicting a source entity on Service A publishes DELETEs for its relations;
+ * Service B must receive those DELETEs and remove the corresponding back-link.
+ *
+ * In production, `SyncTrackerService` triggers `CacheEvictionService.evictExpired` when a
+ * `SyncType.FULL` completes and the post-sync cache contains entries older than the sync
+ * start. The test invokes `evictExpired` directly with a future timestamp so every cached
+ * Elevforhold is evicted deterministically — mimicking the end-of-full-sync eviction path
+ * without having to orchestrate a real full sync.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ActiveProfiles("utdanning-elev")
+@Import(KafkaTestJacksonConfig::class)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=cross-service-eviction-a-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=elev",
+        "fint.consumer.autorelation.enabled=true",
+        "fint.security.enabled=false",
+    ],
+)
+@DirtiesContext
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CrossServiceEvictionIT : KafkaTestcontainersSupport() {
+    companion object {
+        init {
+            createComponentTopics(domain = "utdanning", packageName = "elev")
+            createComponentTopics(domain = "utdanning", packageName = "utdanningsprogram")
+        }
+    }
+
+    @Autowired
+    lateinit var serviceAProducer: EntityProducer
+
+    @Autowired
+    lateinit var serviceACache: CacheService
+
+    @Autowired
+    lateinit var serviceAEviction: CacheEvictionService
+
+    private lateinit var serviceBContext: ConfigurableApplicationContext
+
+    private val serviceBCache: CacheService
+        get() = serviceBContext.getBean(CacheService::class.java)
+
+    @BeforeAll
+    fun startServiceB() {
+        serviceBContext =
+            SpringApplicationBuilder(Application::class.java)
+                .bannerMode(Banner.Mode.OFF)
+                .run(
+                    "--spring.kafka.bootstrap-servers=${KAFKA.bootstrapServers}",
+                    "--spring.kafka.consumer.auto-offset-reset=earliest",
+                    "--spring.kafka.consumer.group-id=cross-service-eviction-b-${UUID.randomUUID()}",
+                    "--novari.kafka.default-replicas=1",
+                    "--fint.relation.base-url=https://test.felleskomponent.no",
+                    "--fint.org-id=fintlabs.no",
+                    "--fint.consumer.org-id=fintlabs.no",
+                    "--fint.consumer.domain=utdanning",
+                    "--fint.consumer.package=utdanningsprogram",
+                    "--fint.consumer.base-url=https://test.felleskomponent.no",
+                    "--fint.consumer.pod-url=http://service-b-eviction-pod",
+                    "--fint.consumer.autorelation.enabled=true",
+                    "--fint.security.enabled=false",
+                    "--server.port=0",
+                )
+    }
+
+    @AfterAll
+    fun stopServiceB() {
+        if (::serviceBContext.isInitialized && serviceBContext.isActive) {
+            serviceBContext.close()
+        }
+    }
+
+    @Test
+    fun `evicting Elevforhold on Service A drops the back-link on Skole on Service B`() {
+        val skoleId = "eviction-skole-${UUID.randomUUID()}"
+        val elevforholdId = "eviction-elevforhold-${UUID.randomUUID()}"
+        val expectedBackLink =
+            "https://test.felleskomponent.no/utdanning/elev/elevforhold/systemId/$elevforholdId"
+
+        serviceAProducer
+            .publish(
+                "skole",
+                SkoleResource().apply {
+                    systemId = Identifikator().apply { identifikatorverdi = skoleId }
+                },
+                skoleId,
+                SyncType.DELTA,
+                UUID.randomUUID().toString(),
+                1,
+                domainName = "utdanning",
+                packageName = "utdanningsprogram",
+            ).get(10, TimeUnit.SECONDS)
+
+        serviceAProducer
+            .publish(
+                "elevforhold",
+                ElevforholdResource().apply {
+                    systemId = Identifikator().apply { identifikatorverdi = elevforholdId }
+                    addSkole(Link.with("systemId/$skoleId"))
+                },
+                elevforholdId,
+                SyncType.DELTA,
+                UUID.randomUUID().toString(),
+                1,
+            ).get(10, TimeUnit.SECONDS)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            val skole = serviceBCache.getCache("skole").get(skoleId)
+            assertNotNull(skole, "Service B should cache Skole")
+            val backLinks = skole.links["elevforhold"]
+            assertNotNull(backLinks, "Skole should gain back-link before eviction")
+            assertTrue(
+                backLinks.any { it.href.equals(expectedBackLink, ignoreCase = true) },
+                "back-link $expectedBackLink should be present before eviction",
+            )
+        }
+
+        // Evicts every Elevforhold entry older than Long.MAX_VALUE — i.e. everything.
+        // The eviction task publishes removeRelations for each evicted entity, which
+        // produces a DELETE message on the utdanningsprogram-relation-update topic.
+        serviceAEviction.evictExpired("elevforhold", Long.MAX_VALUE)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            val skole = serviceBCache.getCache("skole").get(skoleId)
+            assertNotNull(skole, "Skole should still be cached on Service B (only its back-link is removed)")
+            val backLinks = skole.links["elevforhold"]
+            val stillThere = backLinks?.any { it.href.equals(expectedBackLink, ignoreCase = true) } == true
+            assertFalse(
+                stillThere,
+                "Back-link should be dropped after Service A evicts Elevforhold. Got: ${backLinks?.map { it.href }}",
+            )
+        }
+    }
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/crossservice/CrossServiceLoadIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/crossservice/CrossServiceLoadIT.kt
@@ -1,0 +1,172 @@
+package no.fintlabs.consumer.integration.crossservice
+
+import no.fintlabs.Application
+import no.fintlabs.adapter.models.sync.SyncType
+import no.fintlabs.cache.CacheService
+import no.fintlabs.config.KafkaTestcontainersSupport
+import no.fintlabs.consumer.kafka.KafkaTestJacksonConfig
+import no.fintlabs.utils.EntityProducer
+import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
+import no.novari.fint.model.resource.Link
+import no.novari.fint.model.resource.utdanning.elev.ElevforholdResource
+import no.novari.fint.model.resource.utdanning.utdanningsprogram.SkoleResource
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertNotNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.Banner
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+
+/**
+ * §6.4 — Interleaved load across services. Many Skole/Elevforhold pairs are published in
+ * alternating order on Service A; Service B must receive every back-link without loss.
+ *
+ * This is the stress variant of §6.1 — the single-pair happy path is already covered by
+ * `CrossServiceBackLinkIT`. The aim here is to catch concurrency-, ordering-, or
+ * buffering-related losses that only surface under volume.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ActiveProfiles("utdanning-elev")
+@Import(KafkaTestJacksonConfig::class)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=cross-service-load-a-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=elev",
+        "fint.consumer.autorelation.enabled=true",
+        "fint.security.enabled=false",
+    ],
+)
+@DirtiesContext
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CrossServiceLoadIT : KafkaTestcontainersSupport() {
+    companion object {
+        init {
+            createComponentTopics(domain = "utdanning", packageName = "elev")
+            createComponentTopics(domain = "utdanning", packageName = "utdanningsprogram")
+        }
+
+        private const val PAIR_COUNT = 50
+    }
+
+    @Autowired
+    lateinit var serviceAProducer: EntityProducer
+
+    private lateinit var serviceBContext: ConfigurableApplicationContext
+
+    private val serviceBCache: CacheService
+        get() = serviceBContext.getBean(CacheService::class.java)
+
+    @BeforeAll
+    fun startServiceB() {
+        serviceBContext =
+            SpringApplicationBuilder(Application::class.java)
+                .bannerMode(Banner.Mode.OFF)
+                .run(
+                    "--spring.kafka.bootstrap-servers=${KAFKA.bootstrapServers}",
+                    "--spring.kafka.consumer.auto-offset-reset=earliest",
+                    "--spring.kafka.consumer.group-id=cross-service-load-b-${UUID.randomUUID()}",
+                    "--novari.kafka.default-replicas=1",
+                    "--fint.relation.base-url=https://test.felleskomponent.no",
+                    "--fint.org-id=fintlabs.no",
+                    "--fint.consumer.org-id=fintlabs.no",
+                    "--fint.consumer.domain=utdanning",
+                    "--fint.consumer.package=utdanningsprogram",
+                    "--fint.consumer.base-url=https://test.felleskomponent.no",
+                    "--fint.consumer.pod-url=http://service-b-load-pod",
+                    "--fint.consumer.autorelation.enabled=true",
+                    "--fint.security.enabled=false",
+                    "--server.port=0",
+                )
+    }
+
+    @AfterAll
+    fun stopServiceB() {
+        if (::serviceBContext.isInitialized && serviceBContext.isActive) {
+            serviceBContext.close()
+        }
+    }
+
+    @Test
+    fun `every Skole receives its back-link when N pairs are published interleaved`() {
+        val runId = UUID.randomUUID().toString().take(8)
+        val skoleIds = (1..PAIR_COUNT).map { "load-$runId-skole-$it" }
+        val elevforholdIds = (1..PAIR_COUNT).map { "load-$runId-elevforhold-$it" }
+
+        val skoleSyncCorrId = UUID.randomUUID().toString()
+        val elevforholdSyncCorrId = UUID.randomUUID().toString()
+
+        for (i in 0 until PAIR_COUNT) {
+            val skoleId = skoleIds[i]
+            val elevforholdId = elevforholdIds[i]
+
+            serviceAProducer
+                .publish(
+                    "skole",
+                    SkoleResource().apply {
+                        systemId = Identifikator().apply { identifikatorverdi = skoleId }
+                    },
+                    skoleId,
+                    SyncType.FULL,
+                    skoleSyncCorrId,
+                    PAIR_COUNT.toLong(),
+                    domainName = "utdanning",
+                    packageName = "utdanningsprogram",
+                ).get(10, TimeUnit.SECONDS)
+
+            serviceAProducer
+                .publish(
+                    "elevforhold",
+                    ElevforholdResource().apply {
+                        systemId = Identifikator().apply { identifikatorverdi = elevforholdId }
+                        addSkole(Link.with("systemId/$skoleId"))
+                    },
+                    elevforholdId,
+                    SyncType.FULL,
+                    elevforholdSyncCorrId,
+                    PAIR_COUNT.toLong(),
+                ).get(10, TimeUnit.SECONDS)
+        }
+
+        await.atMost(Duration.ofSeconds(60)).untilAsserted {
+            val missing = mutableListOf<String>()
+            for (i in 0 until PAIR_COUNT) {
+                val skoleId = skoleIds[i]
+                val expectedBackLink =
+                    "https://test.felleskomponent.no/utdanning/elev/elevforhold/systemId/${elevforholdIds[i]}"
+                val skole = serviceBCache.getCache("skole").get(skoleId)
+                assertNotNull(skole, "Service B should have cached Skole $skoleId")
+                val backLinks = skole.links["elevforhold"]
+                val hasLink = backLinks?.any { it.href.equals(expectedBackLink, ignoreCase = true) } == true
+                if (!hasLink) {
+                    missing.add(
+                        "Skole $skoleId missing expected link $expectedBackLink (has: ${backLinks?.map { it.href } ?: "no backLinks"})",
+                    )
+                }
+            }
+            assertEquals(
+                emptyList(),
+                missing,
+                "${missing.size}/$PAIR_COUNT Skole entries are missing their back-link. First few: ${missing.take(5)}",
+            )
+        }
+    }
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/crossservice/CrossServiceRestartIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/crossservice/CrossServiceRestartIT.kt
@@ -1,0 +1,174 @@
+package no.fintlabs.consumer.integration.crossservice
+
+import no.fintlabs.Application
+import no.fintlabs.adapter.models.sync.SyncType
+import no.fintlabs.cache.CacheService
+import no.fintlabs.config.KafkaTestcontainersSupport
+import no.fintlabs.consumer.kafka.KafkaTestJacksonConfig
+import no.fintlabs.utils.EntityProducer
+import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
+import no.novari.fint.model.resource.Link
+import no.novari.fint.model.resource.utdanning.elev.ElevforholdResource
+import no.novari.fint.model.resource.utdanning.utdanningsprogram.SkoleResource
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertNotNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.Banner
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertTrue
+
+/**
+ * §6.2 — Closing and re-starting Service B (a full process restart, not just a
+ * container stop/start) must rebuild the back-link state by replaying the
+ * relation-update topic from offset 0.
+ *
+ * Flow:
+ *   1. Service A publishes Skole → Service B caches it.
+ *   2. Service A publishes Elevforhold → ADD on utdanningsprogram-relation-update.
+ *   3. Service B's RelationUpdateConsumer applies the back-link.
+ *   4. Service B's Spring context is closed and replaced. Its in-memory cache and
+ *      unresolved-relation buffer are gone; its consumer group gets a new UUID
+ *      suffix, so seek-to-beginning re-reads both topics.
+ *   5. Expect: the Skole cached by the new Service B has the back-link again.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ActiveProfiles("utdanning-elev")
+@Import(KafkaTestJacksonConfig::class)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=cross-service-restart-a-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=elev",
+        "fint.consumer.autorelation.enabled=true",
+        "fint.security.enabled=false",
+    ],
+)
+@DirtiesContext
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CrossServiceRestartIT : KafkaTestcontainersSupport() {
+    companion object {
+        init {
+            createComponentTopics(domain = "utdanning", packageName = "elev")
+            createComponentTopics(domain = "utdanning", packageName = "utdanningsprogram")
+        }
+    }
+
+    @Autowired
+    lateinit var serviceAProducer: EntityProducer
+
+    private lateinit var serviceBContext: ConfigurableApplicationContext
+
+    private val serviceBCache: CacheService
+        get() = serviceBContext.getBean(CacheService::class.java)
+
+    @BeforeAll
+    fun startServiceB() {
+        serviceBContext = startServiceBContext()
+    }
+
+    @AfterAll
+    fun stopServiceB() {
+        if (::serviceBContext.isInitialized && serviceBContext.isActive) {
+            serviceBContext.close()
+        }
+    }
+
+    @Test
+    fun `Service B full restart rebuilds Skole cache and re-applies back-link via topic replay`() {
+        val skoleId = "restart-skole-${UUID.randomUUID()}"
+        val elevforholdId = "restart-elevforhold-${UUID.randomUUID()}"
+        val expectedBackLink =
+            "https://test.felleskomponent.no/utdanning/elev/elevforhold/systemId/$elevforholdId"
+
+        serviceAProducer
+            .publish(
+                "skole",
+                SkoleResource().apply {
+                    systemId = Identifikator().apply { identifikatorverdi = skoleId }
+                },
+                skoleId,
+                SyncType.DELTA,
+                UUID.randomUUID().toString(),
+                1,
+                domainName = "utdanning",
+                packageName = "utdanningsprogram",
+            ).get(10, TimeUnit.SECONDS)
+
+        serviceAProducer
+            .publish(
+                "elevforhold",
+                ElevforholdResource().apply {
+                    systemId = Identifikator().apply { identifikatorverdi = elevforholdId }
+                    addSkole(Link.with("systemId/$skoleId"))
+                },
+                elevforholdId,
+                SyncType.DELTA,
+                UUID.randomUUID().toString(),
+                1,
+            ).get(10, TimeUnit.SECONDS)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            assertBackLinkPresent(skoleId, expectedBackLink, when_ = "before restart")
+        }
+
+        serviceBContext.close()
+        serviceBContext = startServiceBContext()
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            assertBackLinkPresent(skoleId, expectedBackLink, when_ = "after Service B cold restart")
+        }
+    }
+
+    private fun assertBackLinkPresent(
+        skoleId: String,
+        expectedHref: String,
+        when_: String,
+    ) {
+        val skole = serviceBCache.getCache("skole").get(skoleId)
+        assertNotNull(skole, "Skole $skoleId should be cached on Service B $when_")
+        val backLinks = skole.links["elevforhold"]
+        assertNotNull(backLinks, "Skole should have 'elevforhold' back-link $when_")
+        assertTrue(
+            backLinks.any { it.href.equals(expectedHref, ignoreCase = true) },
+            "Expected back-link $expectedHref $when_. Got: ${backLinks.map { it.href }}",
+        )
+    }
+
+    private fun startServiceBContext(): ConfigurableApplicationContext =
+        SpringApplicationBuilder(Application::class.java)
+            .bannerMode(Banner.Mode.OFF)
+            .run(
+                "--spring.kafka.bootstrap-servers=${KAFKA.bootstrapServers}",
+                "--spring.kafka.consumer.auto-offset-reset=earliest",
+                "--spring.kafka.consumer.group-id=cross-service-restart-b-${UUID.randomUUID()}",
+                "--novari.kafka.default-replicas=1",
+                "--fint.relation.base-url=https://test.felleskomponent.no",
+                "--fint.org-id=fintlabs.no",
+                "--fint.consumer.org-id=fintlabs.no",
+                "--fint.consumer.domain=utdanning",
+                "--fint.consumer.package=utdanningsprogram",
+                "--fint.consumer.base-url=https://test.felleskomponent.no",
+                "--fint.consumer.pod-url=http://service-b-restart-pod",
+                "--fint.consumer.autorelation.enabled=true",
+                "--fint.security.enabled=false",
+                "--server.port=0",
+            )
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/restart/ColdRestartIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/restart/ColdRestartIT.kt
@@ -1,0 +1,155 @@
+package no.fintlabs.consumer.integration.restart
+
+import no.fintlabs.Application
+import no.fintlabs.adapter.models.sync.SyncType
+import no.fintlabs.cache.CacheService
+import no.fintlabs.config.KafkaTestcontainersSupport
+import no.fintlabs.consumer.kafka.KafkaTestJacksonConfig
+import no.fintlabs.utils.EntityProducer
+import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
+import no.novari.fint.model.resource.Link
+import no.novari.fint.model.resource.utdanning.elev.ElevResource
+import no.novari.fint.model.resource.utdanning.elev.ElevforholdResource
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.test.utils.ContainerTestUtils
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * §3.2 — full cold restart: both `EntityConsumer` and `RelationUpdateConsumer` are stopped,
+ * the cache is wiped, and the containers are restarted. After replay (seek-to-beginning on
+ * both topics), the target entity should be re-cached and its auto-relation back-link must
+ * have been re-applied from the relation-update topic.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ActiveProfiles("utdanning-elev")
+@Import(KafkaTestJacksonConfig::class)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=cold-restart-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=elev",
+        "fint.consumer.autorelation.enabled=true",
+        "fint.security.enabled=false",
+    ],
+)
+@DirtiesContext
+class ColdRestartIT : KafkaTestcontainersSupport() {
+    companion object {
+        init {
+            createComponentTopics(domain = "utdanning", packageName = "elev")
+        }
+    }
+
+    @Autowired
+    lateinit var applicationContext: ApplicationContext
+
+    @Autowired
+    lateinit var entityProducer: EntityProducer
+
+    @Autowired
+    lateinit var cacheService: CacheService
+
+    @Test
+    fun `back-links are rebuilt after a cold restart via entity and relation-update topic replay`() {
+        val elevId = "cold-elev-${UUID.randomUUID()}"
+        val elevforholdId = "cold-elevforhold-${UUID.randomUUID()}"
+        val expectedBackLink =
+            "https://test.felleskomponent.no/utdanning/elev/elevforhold/systemId/$elevforholdId"
+
+        publish(
+            "elev",
+            ElevResource().apply {
+                systemId = Identifikator().apply { identifikatorverdi = elevId }
+            },
+            elevId,
+        )
+        publish(
+            "elevforhold",
+            ElevforholdResource().apply {
+                systemId = Identifikator().apply { identifikatorverdi = elevforholdId }
+                addElev(Link.with("systemId/$elevId"))
+            },
+            elevforholdId,
+        )
+
+        await.atMost(Duration.ofSeconds(15)).untilAsserted {
+            assertBackLinkPresent(elevId, expectedBackLink, "before restart")
+        }
+
+        val entityContainer = container("resourceEntityConsumerFactory")
+        val relationUpdateContainer = container("relationUpdateConsumerContainer")
+
+        entityContainer.stop()
+        relationUpdateContainer.stop()
+
+        cacheService.getCache("elev").evictExpired(Long.MAX_VALUE)
+        cacheService.getCache("elevforhold").evictExpired(Long.MAX_VALUE)
+        assertEquals(0, cacheService.getCache("elev").size)
+        assertEquals(0, cacheService.getCache("elevforhold").size)
+
+        entityContainer.start()
+        relationUpdateContainer.start()
+        ContainerTestUtils.waitForAssignment(entityContainer, 1)
+        ContainerTestUtils.waitForAssignment(relationUpdateContainer, 1)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            assertNotNull(cacheService.getCache("elev").get(elevId), "Elev should be re-cached")
+            assertBackLinkPresent(elevId, expectedBackLink, "after cold restart")
+        }
+    }
+
+    private fun publish(
+        resourceName: String,
+        resource: no.novari.fint.model.resource.FintResource,
+        key: String,
+    ) = entityProducer
+        .publish(
+            resourceName,
+            resource,
+            key,
+            SyncType.FULL,
+            UUID.randomUUID().toString(),
+            1,
+        ).get(10, TimeUnit.SECONDS)
+
+    private fun assertBackLinkPresent(
+        elevId: String,
+        expectedHref: String,
+        when_: String,
+    ) {
+        val elev = cacheService.getCache("elev").get(elevId)
+        assertNotNull(elev, "Elev $elevId should be cached $when_")
+        val backLinks = elev.links["elevforhold"]
+        assertNotNull(backLinks, "Elev.links['elevforhold'] should exist $when_")
+        assertTrue(
+            backLinks.any { it.href.equals(expectedHref, ignoreCase = true) },
+            "Expected back-link $expectedHref $when_. Got: ${backLinks.map { it.href }}",
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun container(beanName: String): ConcurrentMessageListenerContainer<String, Any> =
+        applicationContext.getBean(
+            beanName,
+            ConcurrentMessageListenerContainer::class.java,
+        ) as ConcurrentMessageListenerContainer<String, Any>
+}

--- a/src/integrationTest/java/no/fintlabs/consumer/integration/restart/EntityConsumerRestartIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/restart/EntityConsumerRestartIT.kt
@@ -1,0 +1,122 @@
+package no.fintlabs.consumer.integration.restart
+
+import no.fintlabs.Application
+import no.fintlabs.adapter.models.sync.SyncType
+import no.fintlabs.cache.CacheService
+import no.fintlabs.config.KafkaTestcontainersSupport
+import no.fintlabs.consumer.kafka.KafkaTestJacksonConfig
+import no.fintlabs.utils.EntityProducer
+import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
+import no.novari.fint.model.resource.utdanning.vurdering.ElevfravarResource
+import org.awaitility.kotlin.await
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
+import org.springframework.kafka.test.utils.ContainerTestUtils
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+
+/**
+ * §3.1 — proves `EntityConsumer` rebuilds the in-memory cache from the entity topic after a
+ * restart. The container is configured with `seekToBeginningOnAssignment`, so every new
+ * partition assignment (including the one triggered by start → stop → start in a single JVM)
+ * must replay the topic from offset 0.
+ *
+ * The test isolates entity replay from autorelation by disabling `fint.consumer.autorelation.enabled`,
+ * so the `AutoRelationEntityConsumer` and `RelationUpdateConsumer` beans are not registered.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@ActiveProfiles("utdanning-vurdering")
+@Import(KafkaTestJacksonConfig::class)
+@TestPropertySource(
+    properties = [
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.group-id=entity-restart-it",
+        "novari.kafka.default-replicas=1",
+        "fint.relation.base-url=https://test.felleskomponent.no",
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=vurdering",
+        "fint.consumer.autorelation.enabled=false",
+        "fint.security.enabled=false",
+    ],
+)
+@DirtiesContext
+class EntityConsumerRestartIT : KafkaTestcontainersSupport() {
+    companion object {
+        init {
+            createComponentTopics(domain = "utdanning", packageName = "vurdering")
+        }
+    }
+
+    @Autowired
+    lateinit var applicationContext: ApplicationContext
+
+    @Autowired
+    lateinit var entityProducer: EntityProducer
+
+    @Autowired
+    lateinit var cacheService: CacheService
+
+    @Test
+    fun `cache is rebuilt after EntityConsumer restart via seek-to-beginning`() {
+        val resourceName = "elevfravar"
+        val ids = (1..3).map { "restart-${UUID.randomUUID()}" }
+
+        ids.forEach { id ->
+            entityProducer
+                .publish(
+                    resourceName,
+                    ElevfravarResource().apply {
+                        systemId = Identifikator().apply { identifikatorverdi = id }
+                    },
+                    id,
+                    SyncType.FULL,
+                    UUID.randomUUID().toString(),
+                    ids.size.toLong(),
+                ).get(10, TimeUnit.SECONDS)
+        }
+
+        await.atMost(Duration.ofSeconds(15)).untilAsserted {
+            ids.forEach { id ->
+                assertNotNull(cacheService.getCache(resourceName).get(id), "$id should be cached before restart")
+            }
+        }
+
+        val entityContainer = entityConsumerContainer()
+        entityContainer.stop()
+
+        val cache = cacheService.getCache(resourceName)
+        cache.evictExpired(Long.MAX_VALUE)
+        assertEquals(0, cache.size, "cache should be empty after explicit eviction, simulating a cold restart")
+
+        entityContainer.start()
+        ContainerTestUtils.waitForAssignment(entityContainer, 1)
+
+        await.atMost(Duration.ofSeconds(30)).untilAsserted {
+            ids.forEach { id ->
+                assertNotNull(
+                    cacheService.getCache(resourceName).get(id),
+                    "$id should be re-cached after seek-to-beginning replay",
+                )
+            }
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun entityConsumerContainer(): ConcurrentMessageListenerContainer<String, Any> =
+        applicationContext.getBean(
+            "resourceEntityConsumerFactory",
+            ConcurrentMessageListenerContainer::class.java,
+        ) as ConcurrentMessageListenerContainer<String, Any>
+}


### PR DESCRIPTION
## Summary

Builds on the Testcontainers harness from PR #97 to add broad integration coverage for the autorelation pipeline:

- **§3 restart scenarios** — `EntityConsumerRestartIT`, `ColdRestartIT` prove that seek-to-beginning replay rebuilds the cache (and back-links) correctly after a stop/start cycle.
- **§2 move-link** — `OneToManyIT.WithinComponent.moving elev link from A to B ...` covers the correctness of the A-loses / B-gains pattern.
- **§6 cross-service** — four ITs (`CrossServiceBackLinkIT`, `CrossServiceRestartIT`, `CrossServiceEvictionIT`, `CrossServiceLoadIT`) spin up a second Spring context via `SpringApplicationBuilder.run(...)` and exercise the full cross-component flow (Service A's ADD reaches Service B's Skole cache, survives Service B restarts, DELETEs on Service A eviction flow through to Service B, and 50 interleaved pairs all land with no loss).
- **Bug repro** — `StaleBufferLossIT` deterministically reproduces the stale-timestamp buffer loss path: a `RelationUpdate` whose embedded `timestamp` is older than `UnresolvedRelationCache.ttl` is silently dropped on the way into the buffer. This is a candidate explanation for a subset of production missing-back-link cases when consumer restarts hit topic-compacted ADDs older than TTL.
- Harness fix: `KafkaTestcontainersSupport.createTopics` now swallows `TopicExistsException` per topic, because multiple IT classes share the broker per JVM and race on topic creation.

All production code is untouched — this PR is entirely `src/integrationTest/`.

## Dependency order

**This is PR 2 of 3. Merge PR #97 first.** Once #97 lands, GitHub will auto-rebase this onto `develop`.

1. #97 (`test/testcontainers-kafka-harness`) → `develop` ← merge first
2. **This PR** → #97 branch
3. `feat/autorelation-silent-loss-metrics` → this branch

## Test plan

- [ ] `./gradlew integrationTest` passes (80 tests, no failures)
- [ ] Docker Desktop running on the review machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)