### PR TITLE
feat: add silent-loss metrics for autorelation pipeline

### DIFF
--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -88,9 +88,9 @@ Goal: surface silent-loss paths as metric counters so production can quantify ea
 - [x] B.3 `fint.consumer.cache.evicted` counter: `full_sync` (from `CacheEvictionService`)
 
 ### C. `AutoRelationService` branch metrics
-- [ ] C.1 `fint.autorelation.apply` counter: `applied` / `buffered` per target-id
-- [ ] C.2 `apply` failure outcomes: `skipped_for_each`, `skipped_unknown_class`, `failed_deep_copy`, `failed_put`, `failed_other`
-- [ ] C.3 `fint.autorelation.reconcile` counter: `preserved` / `hydrated` / `pruned`
+- [x] C.1 `fint.autorelation.apply` counter: `applied` / `buffered` per target-id
+- [x] C.2 `apply` failure outcomes: per-target try/catch now catches exceptions, emits `skipped_unknown_class` (NPE from `resourceContext.getResource(...)!!`) or `failed`, and continues to the next target — fixes the silent `forEach` abort
+- [x] C.3 `fint.autorelation.reconcile` counter: `preserved` / `hydrated` / `pruned`
 
 ### D. Dead-letter queue (after A–C land)
 - [ ] D.1 Replace logging error handler on `RelationUpdateConsumer` with DLQ + bounded retry

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -70,6 +70,35 @@ Legend: `[x]` covered · `[~]` in progress · `[ ]` not covered
 **B1 — Stale-timestamp buffer loss** (reproduced by `StaleBufferLossIT`).
 An ADD on the relation-update topic whose `timestamp` is older than `UnresolvedRelationCache.ttl` (default 30 days) and whose target is not yet cached is silently lost. Caffeine's `expireAfterCreate` returns a negative duration → clamped to 0 → the buffer entry is evicted before it can be drained. When the target later arrives, `applyPendingLinks` finds nothing and the back-link is never applied. Reachable in production when (a) a buffered ADD is replayed after a consumer restart once the message is older than TTL, or (b) a target takes longer than TTL to appear on its entity topic. Consistent with the missing_back_link class of production defects (~0.14% of links). Fix candidates: use `Instant.now()` as `createdAt` for TTL math, drop the `createdAt` field entirely and rely on Caffeine's insertion time, or dead-letter stale ADDs instead of buffering them.
 
+## Observability / Instrumentation
+
+Goal: surface silent-loss paths as metric counters so production can quantify each failure mode without waiting for tests to catch it. Implement one at a time, each with a focused unit/IT test that asserts the counter moves.
+
+### A. `UnresolvedRelationCache` buffer metrics — `fint.autorelation.buffer.records` (counter)
+- [ ] A.1 `registered` and `appended` outcomes
+- [ ] A.2 `drained` outcome (per-link on `takeRelations`)
+- [ ] A.3 `removed_by_delete` outcome (links removed via `removeRelation`)
+- [ ] A.4 `stillborn` outcome (when `expireAfterCreate` returns 0 — fires on the B1 path)
+- [ ] A.5 `expired` outcome via Caffeine `removalListener`
+- [ ] A.6 `fint.autorelation.buffer.size` gauge per resource
+
+### B. `FintCache` write-path metrics
+- [ ] B.1 `fint.consumer.cache.put` counter: `accepted` / `rejected_stale`
+- [ ] B.2 `fint.consumer.cache.remove` counter: `accepted` / `rejected_stale` / `missing`
+- [ ] B.3 `fint.consumer.cache.evicted` counter: `full_sync` (from `CacheEvictionService`)
+
+### C. `AutoRelationService` branch metrics
+- [ ] C.1 `fint.autorelation.apply` counter: `applied` / `buffered` per target-id
+- [ ] C.2 `apply` failure outcomes: `skipped_for_each`, `skipped_unknown_class`, `failed_deep_copy`, `failed_put`, `failed_other`
+- [ ] C.3 `fint.autorelation.reconcile` counter: `preserved` / `hydrated` / `pruned`
+
+### D. Dead-letter queue (after A–C land)
+- [ ] D.1 Replace logging error handler on `RelationUpdateConsumer` with DLQ + bounded retry
+- [ ] D.2 Same for `EntityConsumer`
+- [ ] D.3 Same for `AutoRelationEntityConsumer`
+
+---
+
 ## Candidate loss scenarios to investigate
 
 Places where back-links could plausibly go missing. Not claims — hypotheses to verify with targeted tests.

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -83,9 +83,9 @@ Goal: surface silent-loss paths as metric counters so production can quantify ea
 - [x] A.6 `fint.autorelation.buffer.size` gauge (total; no per-resource tag)
 
 ### B. `FintCache` write-path metrics
-- [ ] B.1 `fint.consumer.cache.put` counter: `accepted` / `rejected_stale`
-- [ ] B.2 `fint.consumer.cache.remove` counter: `accepted` / `rejected_stale` / `missing`
-- [ ] B.3 `fint.consumer.cache.evicted` counter: `full_sync` (from `CacheEvictionService`)
+- [x] B.1 `fint.consumer.cache.put` counter: `accepted` / `rejected_stale`
+- [x] B.2 `fint.consumer.cache.remove` counter: `accepted` / `rejected_stale` / `missing`
+- [x] B.3 `fint.consumer.cache.evicted` counter: `full_sync` (from `CacheEvictionService`)
 
 ### C. `AutoRelationService` branch metrics
 - [ ] C.1 `fint.autorelation.apply` counter: `applied` / `buffered` per target-id

--- a/AUTORELATION_CHECKLIST.md
+++ b/AUTORELATION_CHECKLIST.md
@@ -75,12 +75,12 @@ An ADD on the relation-update topic whose `timestamp` is older than `UnresolvedR
 Goal: surface silent-loss paths as metric counters so production can quantify each failure mode without waiting for tests to catch it. Implement one at a time, each with a focused unit/IT test that asserts the counter moves.
 
 ### A. `UnresolvedRelationCache` buffer metrics — `fint.autorelation.buffer.records` (counter)
-- [ ] A.1 `registered` and `appended` outcomes
-- [ ] A.2 `drained` outcome (per-link on `takeRelations`)
-- [ ] A.3 `removed_by_delete` outcome (links removed via `removeRelation`)
-- [ ] A.4 `stillborn` outcome (when `expireAfterCreate` returns 0 — fires on the B1 path)
-- [ ] A.5 `expired` outcome via Caffeine `removalListener`
-- [ ] A.6 `fint.autorelation.buffer.size` gauge per resource
+- [x] A.1 `registered` and `appended` outcomes
+- [x] A.2 `drained` outcome (per-link on `takeRelations`)
+- [x] A.3 `removed_by_delete` outcome (links removed via `removeRelation`)
+- [x] A.4 `stillborn` outcome (fires on the B1 path; stale registrations short-circuit out of the cache entirely)
+- [x] A.5 `expired` outcome via Caffeine `evictionListener` (synchronous)
+- [x] A.6 `fint.autorelation.buffer.size` gauge (total; no per-resource tag)
 
 ### B. `FintCache` write-path metrics
 - [ ] B.1 `fint.consumer.cache.put` counter: `accepted` / `rejected_stale`

--- a/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
+++ b/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
@@ -1,6 +1,8 @@
 package no.fintlabs.autorelation
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
 import no.fintlabs.autorelation.buffer.UnresolvedRelationCache
 import no.fintlabs.autorelation.cache.RelationRuleRegistry
 import no.fintlabs.autorelation.model.RelationOperation
@@ -25,6 +27,7 @@ class AutoRelationService(
     private val resourceContext: ResourceContext,
     private val objectMapper: ObjectMapper,
     private val resourceLockService: ResourceLockService,
+    private val meterRegistry: MeterRegistry,
 ) {
     fun applyOrBufferUpdate(relationUpdate: RelationUpdate) =
         relationUpdate.targetIds.forEach { id ->
@@ -37,11 +40,27 @@ class AutoRelationService(
                     resourceCopy.applyUpdate(relationUpdate)
                     linkService.mapLinks(relationUpdate.targetEntity.resourceName, resourceCopy)
                     putInCache(relationUpdate, id, resourceCopy)
+                    incrementApplyOutcome(relationUpdate, "applied")
                 } else {
                     relationUpdate.bufferRelation(id)
+                    incrementApplyOutcome(relationUpdate, "buffered")
                 }
             }
         }
+
+    private fun incrementApplyOutcome(
+        update: RelationUpdate,
+        outcome: String,
+    ) = meterRegistry
+        .counter(
+            "fint.autorelation.apply",
+            listOf(
+                Tag.of("resource", update.targetEntity.resourceName),
+                Tag.of("relation", update.binding.relationName),
+                Tag.of("operation", update.operation.name.lowercase()),
+                Tag.of("outcome", outcome),
+            ),
+        ).increment()
 
     /**
      * Main reconciliation entry point.

--- a/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
+++ b/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
@@ -103,7 +103,7 @@ class AutoRelationService(
             .getInverseRelations(consumerConfig.domain, consumerConfig.packageName, resourceName)
             .filter { it !in managedRelationNames } // Safety net
             .forEach { relation ->
-                fintResource.preserveExistingLinks(oldResource, relation)
+                fintResource.preserveExistingLinks(oldResource, resourceName, relation)
                 fintResource.applyPendingLinks(resourceName, resourceId, relation)
             }
     }
@@ -131,14 +131,19 @@ class AutoRelationService(
                 obsoleteLinksMap,
                 pruningRules,
             )
+            obsoleteLinksMap.forEach { (relation, links) ->
+                incrementReconcileOutcome(resourceName, relation, "pruned", links.size.toDouble())
+            }
         }
     }
 
     private fun FintResource.preserveExistingLinks(
         oldResource: FintResource?,
+        resourceName: String,
         relation: String,
-    ) = oldResource?.links?.get(relation)?.let { oldLinks ->
+    ) = oldResource?.links?.get(relation)?.takeIf { it.isNotEmpty() }?.let { oldLinks ->
         this.addUniqueLinks(relation, oldLinks)
+        incrementReconcileOutcome(resourceName, relation, "preserved", oldLinks.size.toDouble())
     }
 
     private fun FintResource.applyPendingLinks(
@@ -147,7 +152,27 @@ class AutoRelationService(
         relationName: String,
     ) = unresolvedRelationCache
         .takeRelations(resourceName, resourceId, relationName)
-        .let { linksToAttach -> addUniqueLinks(relationName, linksToAttach) }
+        .let { linksToAttach ->
+            addUniqueLinks(relationName, linksToAttach)
+            if (linksToAttach.isNotEmpty()) {
+                incrementReconcileOutcome(resourceName, relationName, "hydrated", linksToAttach.size.toDouble())
+            }
+        }
+
+    private fun incrementReconcileOutcome(
+        resource: String,
+        relation: String,
+        outcome: String,
+        amount: Double = 1.0,
+    ) = meterRegistry
+        .counter(
+            "fint.autorelation.reconcile",
+            listOf(
+                Tag.of("resource", resource),
+                Tag.of("relation", relation),
+                Tag.of("outcome", outcome),
+            ),
+        ).increment(amount)
 
     private fun RelationUpdate.bufferRelation(id: String) =
         with(binding) {

--- a/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
+++ b/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
@@ -14,6 +14,7 @@ import no.fintlabs.consumer.links.LinkService
 import no.fintlabs.consumer.resource.ResourceLockService
 import no.fintlabs.consumer.resource.context.ResourceContext
 import no.novari.fint.model.resource.FintResource
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -31,20 +32,38 @@ class AutoRelationService(
 ) {
     fun applyOrBufferUpdate(relationUpdate: RelationUpdate) =
         relationUpdate.targetIds.forEach { id ->
-            resourceLockService.withLock(relationUpdate.targetEntity.resourceName, id) {
-                val resource = getResourceFromCache(relationUpdate.targetEntity.resourceName, id)
+            try {
+                resourceLockService.withLock(relationUpdate.targetEntity.resourceName, id) {
+                    val resource = getResourceFromCache(relationUpdate.targetEntity.resourceName, id)
 
-                if (resource != null) {
-                    // TODO: Deep copy through JSON serialization + deserialization is a super resource intensive anti-pattern
-                    val resourceCopy = resource.deepCopy(objectMapper, relationUpdate.getResourceClass())
-                    resourceCopy.applyUpdate(relationUpdate)
-                    linkService.mapLinks(relationUpdate.targetEntity.resourceName, resourceCopy)
-                    putInCache(relationUpdate, id, resourceCopy)
-                    incrementApplyOutcome(relationUpdate, "applied")
-                } else {
-                    relationUpdate.bufferRelation(id)
-                    incrementApplyOutcome(relationUpdate, "buffered")
+                    if (resource != null) {
+                        // TODO: Deep copy through JSON serialization + deserialization is a super resource intensive anti-pattern
+                        val resourceCopy = resource.deepCopy(objectMapper, relationUpdate.getResourceClass())
+                        resourceCopy.applyUpdate(relationUpdate)
+                        linkService.mapLinks(relationUpdate.targetEntity.resourceName, resourceCopy)
+                        putInCache(relationUpdate, id, resourceCopy)
+                        incrementApplyOutcome(relationUpdate, "applied")
+                    } else {
+                        relationUpdate.bufferRelation(id)
+                        incrementApplyOutcome(relationUpdate, "buffered")
+                    }
                 }
+            } catch (throwable: Throwable) {
+                // Per-target try/catch so that a failure on one targetId in an M:M ADD does not
+                // silently drop the remaining targets. Classify via outcome tag so ops can
+                // distinguish 'unknown target resource class' (configuration problem) from the
+                // generic failure bucket (JSON / apply / put etc.).
+                val outcome =
+                    if (throwable is NullPointerException) "skipped_unknown_class" else "failed"
+                incrementApplyOutcome(relationUpdate, outcome)
+                logger.error(
+                    "applyOrBufferUpdate failed for target {}/{} relation={} operation={}",
+                    relationUpdate.targetEntity.resourceName,
+                    id,
+                    relationUpdate.binding.relationName,
+                    relationUpdate.operation,
+                    throwable,
+                )
             }
         }
 
@@ -174,4 +193,8 @@ class AutoRelationService(
 
     // use !! to fail-fast if an unknown resource enters the system
     private fun RelationUpdate.getResourceClass() = resourceContext.getResource(targetEntity.resourceName)!!.clazz
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(AutoRelationService::class.java)
+    }
 }

--- a/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
+++ b/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
@@ -3,6 +3,8 @@ package no.fintlabs.autorelation.buffer
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.Expiry
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.novari.fint.model.resource.Link
 import org.springframework.stereotype.Component
@@ -18,6 +20,7 @@ data class TimestampedLinks(
 @Component
 class UnresolvedRelationCache(
     consumerConfiguration: ConsumerConfiguration,
+    private val meterRegistry: MeterRegistry,
 ) {
     private val cache: Cache<RelationKey, TimestampedLinks> =
         buildRelationCache(consumerConfiguration.autorelation.buffer.ttl)
@@ -40,15 +43,19 @@ class UnresolvedRelationCache(
         relationName: String,
         relationLink: Link,
         createdAt: Long,
-    ) = RelationKey(resourceName, resourceId, relationName).let { key ->
+    ) {
+        val key = RelationKey(resourceName, resourceId, relationName)
+        var createdNew = false
         cache.asMap().compute(key) { _, existing ->
             if (existing != null) {
                 existing.links.add(relationLink)
                 existing
             } else {
+                createdNew = true
                 TimestampedLinks(Instant.ofEpochMilli(createdAt), mutableListOf(relationLink))
             }
         }
+        incrementBufferRecord(resourceName, relationName, if (createdNew) "registered" else "appended")
     }
 
     fun removeRelation(
@@ -69,6 +76,24 @@ class UnresolvedRelationCache(
 
     // used for testing
     fun cleanUp() = cache.cleanUp()
+
+    private fun incrementBufferRecord(
+        resource: String,
+        relation: String,
+        outcome: String,
+    ) = meterRegistry
+        .counter(
+            BUFFER_RECORDS_METRIC,
+            listOf(
+                Tag.of("resource", resource),
+                Tag.of("relation", relation),
+                Tag.of("outcome", outcome),
+            ),
+        ).increment()
+
+    private companion object {
+        private const val BUFFER_RECORDS_METRIC = "fint.autorelation.buffer.records"
+    }
 }
 
 private fun buildRelationCache(ttl: Duration): Cache<RelationKey, TimestampedLinks> =

--- a/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
+++ b/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
@@ -22,8 +22,8 @@ class UnresolvedRelationCache(
     consumerConfiguration: ConsumerConfiguration,
     private val meterRegistry: MeterRegistry,
 ) {
-    private val cache: Cache<RelationKey, TimestampedLinks> =
-        buildRelationCache(consumerConfiguration.autorelation.buffer.ttl)
+    private val ttl: Duration = consumerConfiguration.autorelation.buffer.ttl
+    private val cache: Cache<RelationKey, TimestampedLinks> = buildRelationCache(ttl)
 
     fun takeRelations(
         resourceName: String,
@@ -50,6 +50,13 @@ class UnresolvedRelationCache(
         relationLink: Link,
         createdAt: Long,
     ) {
+        // If the ADD is already older than TTL, Caffeine's expireAfterCreate would evict it
+        // at insert time. Short-circuit so the stillborn case is visible in metrics instead of
+        // vanishing silently — this is the B1 bug signal.
+        if (isStale(createdAt)) {
+            incrementBufferRecord(resourceName, relationName, "stillborn")
+            return
+        }
         val key = RelationKey(resourceName, resourceId, relationName)
         var createdNew = false
         cache.asMap().compute(key) { _, existing ->
@@ -63,6 +70,9 @@ class UnresolvedRelationCache(
         }
         incrementBufferRecord(resourceName, relationName, if (createdNew) "registered" else "appended")
     }
+
+    private fun isStale(createdAtEpochMillis: Long): Boolean =
+        Duration.between(Instant.ofEpochMilli(createdAtEpochMillis), Instant.now()) >= ttl
 
     fun removeRelation(
         resourceName: String,

--- a/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
+++ b/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
@@ -29,13 +29,19 @@ class UnresolvedRelationCache(
         resourceName: String,
         resourceId: String,
         relationName: String,
-    ): List<Link> =
-        cache
-            .asMap()
-            .remove(RelationKey(resourceName, resourceId, relationName))
-            ?.links
-            ?.toList()
-            .orEmpty()
+    ): List<Link> {
+        val links =
+            cache
+                .asMap()
+                .remove(RelationKey(resourceName, resourceId, relationName))
+                ?.links
+                ?.toList()
+                .orEmpty()
+        if (links.isNotEmpty()) {
+            incrementBufferRecord(resourceName, relationName, "drained", links.size.toDouble())
+        }
+        return links
+    }
 
     fun registerRelation(
         resourceName: String,
@@ -81,6 +87,7 @@ class UnresolvedRelationCache(
         resource: String,
         relation: String,
         outcome: String,
+        amount: Double = 1.0,
     ) = meterRegistry
         .counter(
             BUFFER_RECORDS_METRIC,
@@ -89,7 +96,7 @@ class UnresolvedRelationCache(
                 Tag.of("relation", relation),
                 Tag.of("outcome", outcome),
             ),
-        ).increment()
+        ).increment(amount)
 
     private companion object {
         private const val BUFFER_RECORDS_METRIC = "fint.autorelation.buffer.records"

--- a/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
+++ b/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.Expiry
 import com.github.benmanes.caffeine.cache.RemovalCause
+import com.github.benmanes.caffeine.cache.Scheduler
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import no.fintlabs.consumer.config.ConsumerConfiguration
@@ -25,6 +26,10 @@ class UnresolvedRelationCache(
 ) {
     private val ttl: Duration = consumerConfiguration.autorelation.buffer.ttl
     private val cache: Cache<RelationKey, TimestampedLinks> = buildRelationCache()
+
+    init {
+        meterRegistry.gauge(BUFFER_SIZE_METRIC, cache) { it.estimatedSize().toDouble() }
+    }
 
     fun takeRelations(
         resourceName: String,
@@ -117,6 +122,7 @@ class UnresolvedRelationCache(
     private fun buildRelationCache(): Cache<RelationKey, TimestampedLinks> =
         Caffeine
             .newBuilder()
+            .scheduler(Scheduler.systemScheduler())
             .expireAfter(
                 object : Expiry<RelationKey, TimestampedLinks> {
                     override fun expireAfterCreate(
@@ -150,5 +156,6 @@ class UnresolvedRelationCache(
 
     private companion object {
         private const val BUFFER_RECORDS_METRIC = "fint.autorelation.buffer.records"
+        private const val BUFFER_SIZE_METRIC = "fint.autorelation.buffer.size"
     }
 }

--- a/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
+++ b/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
@@ -69,14 +69,19 @@ class UnresolvedRelationCache(
         resourceId: String,
         relationName: String,
         relationLink: Link,
-    ) = RelationKey(resourceName, resourceId, relationName).let { key ->
+    ) {
+        val key = RelationKey(resourceName, resourceId, relationName)
+        var removed = false
         cache.asMap().computeIfPresent(key) { _, existing ->
-            existing.links.remove(relationLink)
+            removed = existing.links.remove(relationLink)
             if (existing.links.isEmpty()) {
                 null
             } else {
                 existing
             }
+        }
+        if (removed) {
+            incrementBufferRecord(resourceName, relationName, "removed_by_delete")
         }
     }
 

--- a/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
+++ b/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
@@ -3,6 +3,7 @@ package no.fintlabs.autorelation.buffer
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.Expiry
+import com.github.benmanes.caffeine.cache.RemovalCause
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import no.fintlabs.consumer.config.ConsumerConfiguration
@@ -23,7 +24,7 @@ class UnresolvedRelationCache(
     private val meterRegistry: MeterRegistry,
 ) {
     private val ttl: Duration = consumerConfiguration.autorelation.buffer.ttl
-    private val cache: Cache<RelationKey, TimestampedLinks> = buildRelationCache(ttl)
+    private val cache: Cache<RelationKey, TimestampedLinks> = buildRelationCache()
 
     fun takeRelations(
         resourceName: String,
@@ -113,37 +114,41 @@ class UnresolvedRelationCache(
             ),
         ).increment(amount)
 
+    private fun buildRelationCache(): Cache<RelationKey, TimestampedLinks> =
+        Caffeine
+            .newBuilder()
+            .expireAfter(
+                object : Expiry<RelationKey, TimestampedLinks> {
+                    override fun expireAfterCreate(
+                        key: RelationKey,
+                        value: TimestampedLinks,
+                        currentTime: Long,
+                    ): Long {
+                        val remaining = ttl.minus(Duration.between(value.createdAt, Instant.now()))
+                        return if (remaining.isNegative) 0 else TimeUnit.MILLISECONDS.toNanos(remaining.toMillis())
+                    }
+
+                    override fun expireAfterUpdate(
+                        key: RelationKey,
+                        value: TimestampedLinks,
+                        currentTime: Long,
+                        currentDuration: Long,
+                    ): Long = currentDuration
+
+                    override fun expireAfterRead(
+                        key: RelationKey,
+                        value: TimestampedLinks,
+                        currentTime: Long,
+                        currentDuration: Long,
+                    ): Long = currentDuration
+                },
+            ).evictionListener<RelationKey, TimestampedLinks> { key, value, cause ->
+                if (cause == RemovalCause.EXPIRED && key != null && value != null && value.links.isNotEmpty()) {
+                    incrementBufferRecord(key.resource, key.relation, "expired", value.links.size.toDouble())
+                }
+            }.build()
+
     private companion object {
         private const val BUFFER_RECORDS_METRIC = "fint.autorelation.buffer.records"
     }
 }
-
-private fun buildRelationCache(ttl: Duration): Cache<RelationKey, TimestampedLinks> =
-    Caffeine
-        .newBuilder()
-        .expireAfter(
-            object : Expiry<RelationKey, TimestampedLinks> {
-                override fun expireAfterCreate(
-                    key: RelationKey,
-                    value: TimestampedLinks,
-                    currentTime: Long,
-                ): Long {
-                    val remaining = ttl.minus(Duration.between(value.createdAt, Instant.now()))
-                    return if (remaining.isNegative) 0 else TimeUnit.MILLISECONDS.toNanos(remaining.toMillis())
-                }
-
-                override fun expireAfterUpdate(
-                    key: RelationKey,
-                    value: TimestampedLinks,
-                    currentTime: Long,
-                    currentDuration: Long,
-                ): Long = currentDuration
-
-                override fun expireAfterRead(
-                    key: RelationKey,
-                    value: TimestampedLinks,
-                    currentTime: Long,
-                    currentDuration: Long,
-                ): Long = currentDuration
-            },
-        ).build()

--- a/src/main/java/no/fintlabs/cache/CacheEvictionService.kt
+++ b/src/main/java/no/fintlabs/cache/CacheEvictionService.kt
@@ -1,6 +1,7 @@
 package no.fintlabs.cache
 
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Timer
 import no.fintlabs.autorelation.RelationEventService
 import no.fintlabs.consumer.config.ConsumerConfiguration
@@ -67,13 +68,19 @@ class CacheEvictionService(
                 cacheService.getCache(resourceName)
             }
         timed(resourceName, "eviction.cache.evictExpired") {
-            cache
-                .evictExpired(startTimestamp)
-                .forEach {
-                    timed(resourceName, "eviction.relation.removeRelations") {
-                        publishRelationDeleteRequest(resourceName, it.first, it.second)
-                    }
+            val evicted = cache.evictExpired(startTimestamp)
+            if (evicted.isNotEmpty()) {
+                meterRegistry
+                    .counter(
+                        "fint.consumer.cache.evicted",
+                        listOf(Tag.of("resource", resourceName), Tag.of("cause", "full_sync")),
+                    ).increment(evicted.size.toDouble())
+            }
+            evicted.forEach {
+                timed(resourceName, "eviction.relation.removeRelations") {
+                    publishRelationDeleteRequest(resourceName, it.first, it.second)
                 }
+            }
         }
     }
 

--- a/src/main/java/no/fintlabs/cache/CacheService.kt
+++ b/src/main/java/no/fintlabs/cache/CacheService.kt
@@ -1,16 +1,19 @@
 package no.fintlabs.cache
 
+import io.micrometer.core.instrument.MeterRegistry
 import no.novari.fint.model.resource.FintResource
 import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
 
 @Service
-class CacheService {
+class CacheService(
+    private val meterRegistry: MeterRegistry,
+) {
     private val resourceCaches: MutableMap<String, FintCache<FintResource>> =
         ConcurrentHashMap<String, FintCache<FintResource>>()
 
     fun getCachedResourceNames(): Set<String> = resourceCaches.keys
 
     fun getCache(resourceName: String): FintCache<FintResource> =
-        resourceCaches.computeIfAbsent(resourceName.lowercase()) { FintCache() }
+        resourceCaches.computeIfAbsent(resourceName.lowercase()) { FintCache(it, meterRegistry) }
 }

--- a/src/main/java/no/fintlabs/cache/FintCache.kt
+++ b/src/main/java/no/fintlabs/cache/FintCache.kt
@@ -1,5 +1,8 @@
 package no.fintlabs.cache
 
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.fint.antlr.odata.ODataFilterService
 import no.novari.fint.model.resource.FintResource
 import org.springframework.http.HttpStatus
@@ -26,7 +29,10 @@ import kotlin.math.max
  * Each entry carries the Kafka record timestamp used for incremental reads
  * ([sinceTimestamp]), expiration ([evictExpired]), and last-update tracking.
  */
-class FintCache<T : FintResource> {
+class FintCache<T : FintResource>(
+    private val resourceName: String = "unknown",
+    private val meterRegistry: MeterRegistry = SimpleMeterRegistry(),
+) {
     private val index: MutableMap<IndexKey, CacheEntry> = mutableMapOf()
     private val entryStore: HashMap<String, CacheEntry> = HashMap()
     private val sortedEntries: TreeMap<SortKey, CacheEntry> = TreeMap()
@@ -97,7 +103,10 @@ class FintCache<T : FintResource> {
         lock.write {
             val existing = entryStore[resourceId]
             if (existing != null) {
-                if (timestamp < existing.timestamp) return@write
+                if (timestamp < existing.timestamp) {
+                    incrementPutOutcome("rejected_stale")
+                    return@write
+                }
                 sortedEntries.remove(SortKey(existing.timestamp, resourceId))
                 removeFromIndexes(existing.resource)
             }
@@ -105,6 +114,7 @@ class FintCache<T : FintResource> {
             sortedEntries[SortKey(timestamp, resourceId)] = entry
             updateIndexes(entry)
             lastUpdated = timestamp
+            incrementPutOutcome("accepted")
         }
     }
 
@@ -261,6 +271,13 @@ class FintCache<T : FintResource> {
 
             removedResources
         }
+
+    private fun incrementPutOutcome(outcome: String) =
+        meterRegistry
+            .counter(
+                "fint.consumer.cache.put",
+                listOf(Tag.of("resource", resourceName), Tag.of("outcome", outcome)),
+            ).increment()
 
     private fun updateIndexes(entry: CacheEntry) {
         entry.resource.identifikators

--- a/src/main/java/no/fintlabs/cache/FintCache.kt
+++ b/src/main/java/no/fintlabs/cache/FintCache.kt
@@ -235,11 +235,16 @@ class FintCache<T : FintResource>(
         timestamp: Long,
     ) = lock.write {
         val entry = entryStore[resourceId]
-        if (entry != null && timestamp > entry.timestamp) {
-            entryStore.remove(resourceId)
-            sortedEntries.remove(SortKey(entry.timestamp, resourceId))
-            removeFromIndexes(entry.resource)
-            lastUpdated = timestamp
+        when {
+            entry == null -> incrementRemoveOutcome("missing")
+            timestamp > entry.timestamp -> {
+                entryStore.remove(resourceId)
+                sortedEntries.remove(SortKey(entry.timestamp, resourceId))
+                removeFromIndexes(entry.resource)
+                lastUpdated = timestamp
+                incrementRemoveOutcome("accepted")
+            }
+            else -> incrementRemoveOutcome("rejected_stale")
         }
     }
 
@@ -276,6 +281,13 @@ class FintCache<T : FintResource>(
         meterRegistry
             .counter(
                 "fint.consumer.cache.put",
+                listOf(Tag.of("resource", resourceName), Tag.of("outcome", outcome)),
+            ).increment()
+
+    private fun incrementRemoveOutcome(outcome: String) =
+        meterRegistry
+            .counter(
+                "fint.consumer.cache.remove",
                 listOf(Tag.of("resource", resourceName), Tag.of("outcome", outcome)),
             ).increment()
 

--- a/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
@@ -129,6 +129,51 @@ class AutoRelationServiceTest {
         }
 
         @Test
+        fun `failed counter increments when a target throws and subsequent targets still process`() {
+            val twoTargetUpdate =
+                createRelationUpdate().copy(targetIds = listOf("target-a", "target-b"))
+            val resourceA = createElevFravar("target-a")
+            val resourceB = createElevFravar("target-b")
+
+            every {
+                cacheService.getCache(twoTargetUpdate.targetEntity.resourceName).get("target-a")
+            } returns resourceA
+            every {
+                cacheService.getCache(twoTargetUpdate.targetEntity.resourceName).get("target-b")
+            } returns resourceB
+            // Force linkService.mapLinks to throw specifically for target-a so the first iteration
+            // fails; target-b should still be processed.
+            every {
+                linkService.mapLinks(
+                    twoTargetUpdate.targetEntity.resourceName,
+                    match {
+                        (it as? ElevfravarResource)?.systemId?.identifikatorverdi == "target-a"
+                    },
+                )
+            } throws RuntimeException("boom")
+
+            service.applyOrBufferUpdate(twoTargetUpdate)
+
+            kotlin.test.assertEquals(1.0, applyCounter("failed"))
+            kotlin.test.assertEquals(1.0, applyCounter("applied"), "target-b should still apply despite target-a failing")
+        }
+
+        @Test
+        fun `skipped_unknown_class counter fires on NullPointerException from unknown target class`() {
+            val resource = createElevFravar()
+            val targetId = relationUpdate.targetIds.first()
+            every {
+                cacheService.getCache(relationUpdate.targetEntity.resourceName).get(targetId)
+            } returns resource
+            every { resourceContext.getResource(relationUpdate.targetEntity.resourceName) } returns null
+
+            service.applyOrBufferUpdate(relationUpdate)
+
+            kotlin.test.assertEquals(1.0, applyCounter("skipped_unknown_class"))
+            kotlin.test.assertEquals(0.0, applyCounter("applied"))
+        }
+
+        @Test
         fun `should buffer DELETE operation if resource does not exist`() {
             val deleteUpdate = createRelationUpdate(operation = RelationOperation.DELETE)
             val targetId = deleteUpdate.targetIds.first()

--- a/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
@@ -72,6 +72,17 @@ class AutoRelationServiceTest {
             .counter()
             ?.count() ?: 0.0
 
+    private fun reconcileCounter(
+        outcome: String,
+        relation: String,
+    ): Double =
+        meterRegistry
+            .find("fint.autorelation.reconcile")
+            .tag("outcome", outcome)
+            .tag("relation", relation)
+            .counter()
+            ?.count() ?: 0.0
+
     private val relationUpdate: RelationUpdate = createRelationUpdate()
 
     @BeforeEach
@@ -280,6 +291,7 @@ class AutoRelationServiceTest {
             service.reconcileLinks(resourceName, resourceId, newResource)
 
             assert(newResource.links[relationName]?.contains(oldLink) == true)
+            kotlin.test.assertEquals(1.0, reconcileCounter("preserved", relationName))
         }
 
         @Test
@@ -307,6 +319,34 @@ class AutoRelationServiceTest {
             service.reconcileLinks(resourceName, resourceId, newResource)
 
             assert(newResource.links[relationName]?.contains(pendingLink) == true)
+            kotlin.test.assertEquals(1.0, reconcileCounter("hydrated", relationName))
+        }
+
+        @Test
+        fun `pruned counter reflects obsolete links removed during pruning`() {
+            val resourceName = "elevfravar"
+            val resourceId = "123"
+            val relationName = "rel_test"
+
+            val oldResource =
+                createElevFravar(resourceId).apply {
+                    addLink(relationName, Link.with("http://old-a"))
+                    addLink(relationName, Link.with("http://old-b"))
+                }
+            val newResource = createElevFravar(resourceId)
+
+            every { consumerConfig.domain } returns "test-domain"
+            every { consumerConfig.packageName } returns "test-pkg"
+
+            val mockRule = mockk<RelationSyncRule>(relaxed = true)
+            every { mockRule.targetRelation } returns relationName
+            every { mockRule.shouldPruneLinks() } returns true
+            every { relationRuleRegistry.getRules("test-domain", "test-pkg", resourceName) } returns listOf(mockRule)
+            every { cacheService.getCache(resourceName).get(resourceId) } returns oldResource
+
+            service.reconcileLinks(resourceName, resourceId, newResource)
+
+            kotlin.test.assertEquals(2.0, reconcileCounter("pruned", relationName))
         }
     }
 

--- a/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
@@ -2,6 +2,7 @@ package no.fintlabs.autorelation
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.Called
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -45,6 +46,7 @@ class AutoRelationServiceTest {
             }
         }
 
+    private val meterRegistry = SimpleMeterRegistry()
     private var service: AutoRelationService =
         AutoRelationService(
             linkService,
@@ -56,7 +58,19 @@ class AutoRelationServiceTest {
             resourceContext,
             objectMapper,
             resourceLockService,
+            meterRegistry,
         )
+
+    private fun applyCounter(
+        outcome: String,
+        operation: RelationOperation = RelationOperation.ADD,
+    ): Double =
+        meterRegistry
+            .find("fint.autorelation.apply")
+            .tag("outcome", outcome)
+            .tag("operation", operation.name.lowercase())
+            .counter()
+            ?.count() ?: 0.0
 
     private val relationUpdate: RelationUpdate = createRelationUpdate()
 
@@ -86,6 +100,8 @@ class AutoRelationServiceTest {
 
             verify(exactly = 1) { linkService.mapLinks(relationUpdate.targetEntity.resourceName, any()) }
             verify { unresolvedRelationCache wasNot Called }
+            kotlin.test.assertEquals(1.0, applyCounter("applied"))
+            kotlin.test.assertEquals(0.0, applyCounter("buffered"))
         }
 
         @Test
@@ -108,6 +124,8 @@ class AutoRelationServiceTest {
                     createdAt = addUpdate.timestamp,
                 )
             }
+            kotlin.test.assertEquals(1.0, applyCounter("buffered"))
+            kotlin.test.assertEquals(0.0, applyCounter("applied"))
         }
 
         @Test

--- a/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
@@ -95,6 +95,26 @@ class UnresolvedRelationCacheTest {
     }
 
     @Test
+    fun `removed_by_delete counter increments when a buffered link is removed`() {
+        val now = System.currentTimeMillis()
+        val link1 = Link.with("http://l1")
+        val link2 = Link.with("http://l2")
+        service.registerRelation(resource, resourceId, relation, link1, now)
+        service.registerRelation(resource, resourceId, relation, link2, now)
+
+        service.removeRelation(resource, resourceId, relation, link1)
+
+        assertEquals(1.0, bufferCounter("removed_by_delete"))
+    }
+
+    @Test
+    fun `removed_by_delete counter does not fire when the target link is not present`() {
+        service.removeRelation(resource, resourceId, relation, Link.with("http://not-there"))
+
+        assertEquals(0.0, bufferCounter("removed_by_delete"))
+    }
+
+    @Test
     fun `drained counter does not increment when takeRelations finds nothing`() {
         service.takeRelations(resource, resourceId, relation)
 

--- a/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
@@ -95,6 +95,18 @@ class UnresolvedRelationCacheTest {
     }
 
     @Test
+    fun `stillborn counter fires when createdAt is older than TTL`() {
+        val shortCache = cacheWithTtl(Duration.ofSeconds(1), meterRegistry)
+        val staleTimestamp = System.currentTimeMillis() - Duration.ofSeconds(30).toMillis()
+
+        shortCache.registerRelation(resource, resourceId, relation, Link.with("http://stale"), staleTimestamp)
+
+        assertEquals(1.0, bufferCounter("stillborn"))
+        assertEquals(0.0, bufferCounter("registered"), "stillborn entry should not count as registered")
+        assertEquals(emptyList<Link>(), shortCache.takeRelations(resource, resourceId, relation))
+    }
+
+    @Test
     fun `removed_by_delete counter increments when a buffered link is removed`() {
         val now = System.currentTimeMillis()
         val link1 = Link.with("http://l1")

--- a/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
@@ -95,25 +95,42 @@ class UnresolvedRelationCacheTest {
     }
 
     @Test
+    fun `buffer size gauge reflects the number of entries in the cache`() {
+        service.registerRelation(resource, resourceId, relation, Link.with("http://l1"), System.currentTimeMillis())
+        service.registerRelation(resource, "other-id", relation, Link.with("http://l2"), System.currentTimeMillis())
+
+        val size =
+            meterRegistry
+                .find("fint.autorelation.buffer.size")
+                .gauge()
+                ?.value() ?: 0.0
+        assertEquals(2.0, size)
+    }
+
+    @Test
     fun `expired counter fires when a live buffer entry expires via TTL`() {
         val registry = SimpleMeterRegistry()
-        val shortCache = cacheWithTtl(Duration.ofMillis(100), registry)
+        val shortCache = cacheWithTtl(Duration.ofMillis(500), registry)
 
         shortCache.registerRelation(resource, resourceId, relation, Link.with("http://l1"), System.currentTimeMillis())
         shortCache.registerRelation(resource, resourceId, relation, Link.with("http://l2"), System.currentTimeMillis())
 
-        Thread.sleep(300)
-        shortCache.cleanUp()
-
-        val expired =
-            registry
-                .find("fint.autorelation.buffer.records")
-                .tag("resource", resource)
-                .tag("relation", relation)
-                .tag("outcome", "expired")
-                .counter()
-                ?.count() ?: 0.0
-        assertEquals(2.0, expired, "expired counter should reflect the number of links in the evicted entry")
+        // Variable-expiry Caffeine uses a hierarchical wheel; give it ample time past the TTL
+        // and call cleanUp() to force maintenance-time eviction.
+        org.awaitility.kotlin.await
+            .atMost(java.time.Duration.ofSeconds(5))
+            .until {
+                shortCache.cleanUp()
+                val count =
+                    registry
+                        .find("fint.autorelation.buffer.records")
+                        .tag("resource", resource)
+                        .tag("relation", relation)
+                        .tag("outcome", "expired")
+                        .counter()
+                        ?.count() ?: 0.0
+                count >= 2.0
+            }
     }
 
     @Test

--- a/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
@@ -82,6 +82,26 @@ class UnresolvedRelationCacheTest {
     }
 
     @Test
+    fun `drained counter increments by the number of links returned`() {
+        val now = System.currentTimeMillis()
+        service.registerRelation(resource, resourceId, relation, Link.with("http://l1"), now)
+        service.registerRelation(resource, resourceId, relation, Link.with("http://l2"), now)
+        service.registerRelation(resource, resourceId, relation, Link.with("http://l3"), now)
+
+        val drained = service.takeRelations(resource, resourceId, relation)
+
+        assertEquals(3, drained.size)
+        assertEquals(3.0, bufferCounter("drained"))
+    }
+
+    @Test
+    fun `drained counter does not increment when takeRelations finds nothing`() {
+        service.takeRelations(resource, resourceId, relation)
+
+        assertEquals(0.0, bufferCounter("drained"))
+    }
+
+    @Test
     fun `appended counter increments when registerRelation adds to an existing key`() {
         val now = System.currentTimeMillis()
         service.registerRelation(resource, resourceId, relation, Link.with("http://l1"), now)

--- a/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
@@ -1,5 +1,7 @@
 package no.fintlabs.autorelation
 
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
 import io.mockk.mockk
 import no.fintlabs.autorelation.buffer.UnresolvedRelationCache
@@ -14,21 +16,35 @@ import java.time.Duration
 
 class UnresolvedRelationCacheTest {
     private lateinit var service: UnresolvedRelationCache
+    private lateinit var meterRegistry: MeterRegistry
 
     private val resource = "person"
     private val resourceId = "123"
     private val relation = "manager"
 
-    private fun cacheWithTtl(ttl: Duration): UnresolvedRelationCache {
+    private fun cacheWithTtl(
+        ttl: Duration,
+        registry: MeterRegistry = SimpleMeterRegistry(),
+    ): UnresolvedRelationCache {
         val config = mockk<ConsumerConfiguration>()
         every { config.autorelation } returns AutorelationConfig(buffer = AutorelationConfig.BufferConfig(ttl = ttl))
-        return UnresolvedRelationCache(config)
+        return UnresolvedRelationCache(config, registry)
     }
 
     @BeforeEach
     fun setup() {
-        service = cacheWithTtl(Duration.ofDays(7))
+        meterRegistry = SimpleMeterRegistry()
+        service = cacheWithTtl(Duration.ofDays(7), meterRegistry)
     }
+
+    private fun bufferCounter(outcome: String): Double =
+        meterRegistry
+            .find("fint.autorelation.buffer.records")
+            .tag("resource", resource)
+            .tag("relation", relation)
+            .tag("outcome", outcome)
+            .counter()
+            ?.count() ?: 0.0
 
     @Test
     fun `registerRelation stores link and takeRelations retrieves it`() {
@@ -55,6 +71,25 @@ class UnresolvedRelationCacheTest {
         val secondCall = service.takeRelations(resource, resourceId, relation)
 
         assertEquals(emptyList<Link>(), secondCall)
+    }
+
+    @Test
+    fun `registered counter increments on first registerRelation for a key`() {
+        service.registerRelation(resource, resourceId, relation, Link.with("http://l"), System.currentTimeMillis())
+
+        assertEquals(1.0, bufferCounter("registered"))
+        assertEquals(0.0, bufferCounter("appended"))
+    }
+
+    @Test
+    fun `appended counter increments when registerRelation adds to an existing key`() {
+        val now = System.currentTimeMillis()
+        service.registerRelation(resource, resourceId, relation, Link.with("http://l1"), now)
+        service.registerRelation(resource, resourceId, relation, Link.with("http://l2"), now)
+        service.registerRelation(resource, resourceId, relation, Link.with("http://l3"), now)
+
+        assertEquals(1.0, bufferCounter("registered"))
+        assertEquals(2.0, bufferCounter("appended"))
     }
 
     @Test

--- a/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
@@ -95,6 +95,28 @@ class UnresolvedRelationCacheTest {
     }
 
     @Test
+    fun `expired counter fires when a live buffer entry expires via TTL`() {
+        val registry = SimpleMeterRegistry()
+        val shortCache = cacheWithTtl(Duration.ofMillis(100), registry)
+
+        shortCache.registerRelation(resource, resourceId, relation, Link.with("http://l1"), System.currentTimeMillis())
+        shortCache.registerRelation(resource, resourceId, relation, Link.with("http://l2"), System.currentTimeMillis())
+
+        Thread.sleep(300)
+        shortCache.cleanUp()
+
+        val expired =
+            registry
+                .find("fint.autorelation.buffer.records")
+                .tag("resource", resource)
+                .tag("relation", relation)
+                .tag("outcome", "expired")
+                .counter()
+                ?.count() ?: 0.0
+        assertEquals(2.0, expired, "expired counter should reflect the number of links in the evicted entry")
+    }
+
+    @Test
     fun `stillborn counter fires when createdAt is older than TTL`() {
         val shortCache = cacheWithTtl(Duration.ofSeconds(1), meterRegistry)
         val staleTimestamp = System.currentTimeMillis() - Duration.ofSeconds(30).toMillis()

--- a/src/test/java/no/fintlabs/cache/CacheEvictionServiceTest.kt
+++ b/src/test/java/no/fintlabs/cache/CacheEvictionServiceTest.kt
@@ -25,10 +25,12 @@ class CacheEvictionServiceTest {
     private lateinit var relationEventService: RelationEventService
     private lateinit var consumerConfiguration: ConsumerConfiguration
     private lateinit var cacheEvictionService: CacheEvictionService
+    private lateinit var meterRegistry: SimpleMeterRegistry
 
     @BeforeEach
     fun setUp() {
-        cacheService = CacheService(SimpleMeterRegistry())
+        meterRegistry = SimpleMeterRegistry()
+        cacheService = CacheService(meterRegistry)
         relationEventService = mockk(relaxed = true)
         consumerConfiguration =
             mockk {
@@ -39,7 +41,7 @@ class CacheEvictionServiceTest {
                 cacheService = cacheService,
                 relationEventService = relationEventService,
                 consumerConfiguration = consumerConfiguration,
-                meterRegistry = SimpleMeterRegistry(),
+                meterRegistry = meterRegistry,
             )
     }
 
@@ -73,6 +75,25 @@ class CacheEvictionServiceTest {
             relationEventService.removeRelations(resourceName, key1, resource1)
             relationEventService.removeRelations(resourceName, key2, resource2)
         }
+    }
+
+    @Test
+    fun `evicted counter reflects the number of entries cleared by a full-sync eviction`() {
+        val resourceName = "elevfravar"
+        val cache = cacheService.getCache(resourceName)
+        cache.put("k1", ElevfravarResource(), 1)
+        cache.put("k2", ElevfravarResource(), 2)
+        cache.put("k3", ElevfravarResource(), 3)
+        cacheEvictionService.evictExpired(resourceName, Long.MAX_VALUE)
+
+        val evicted =
+            meterRegistry
+                .find("fint.consumer.cache.evicted")
+                .tag("resource", resourceName)
+                .tag("cause", "full_sync")
+                .counter()
+                ?.count() ?: 0.0
+        assertTrue(evicted >= 3.0, "expected at least 3 evicted, got $evicted")
     }
 
     @Test

--- a/src/test/java/no/fintlabs/cache/CacheEvictionServiceTest.kt
+++ b/src/test/java/no/fintlabs/cache/CacheEvictionServiceTest.kt
@@ -28,7 +28,7 @@ class CacheEvictionServiceTest {
 
     @BeforeEach
     fun setUp() {
-        cacheService = CacheService()
+        cacheService = CacheService(SimpleMeterRegistry())
         relationEventService = mockk(relaxed = true)
         consumerConfiguration =
             mockk {

--- a/src/test/java/no/fintlabs/cache/FintCacheTest.kt
+++ b/src/test/java/no/fintlabs/cache/FintCacheTest.kt
@@ -30,6 +30,14 @@ class FintCacheTest {
             .counter()
             ?.count() ?: 0.0
 
+    private fun removeCounter(outcome: String): Double =
+        meterRegistry
+            .find("fint.consumer.cache.remove")
+            .tag("resource", "elev")
+            .tag("outcome", outcome)
+            .counter()
+            ?.count() ?: 0.0
+
     @Test
     fun `cache size is empty when nothing is added`() {
         assertEquals(0, cache.size)
@@ -83,6 +91,34 @@ class FintCacheTest {
 
         assertEquals(1.0, putCounter("accepted"))
         assertEquals(1.0, putCounter("rejected_stale"))
+    }
+
+    @Test
+    fun `remove accepted counter increments when entry is removed`() {
+        val elev = createElevResource("A")
+        cache.put(elev.systemId.identifikatorverdi, elev, 10)
+        cache.remove(elev.systemId.identifikatorverdi, 20)
+
+        assertEquals(1.0, removeCounter("accepted"))
+    }
+
+    @Test
+    fun `remove rejected_stale counter increments for equal or older timestamp`() {
+        val elev = createElevResource("A")
+        cache.put(elev.systemId.identifikatorverdi, elev, 10)
+
+        cache.remove(elev.systemId.identifikatorverdi, 10)
+        cache.remove(elev.systemId.identifikatorverdi, 5)
+
+        assertEquals(2.0, removeCounter("rejected_stale"))
+        assertEquals(0.0, removeCounter("accepted"))
+    }
+
+    @Test
+    fun `remove missing counter increments when entry is not in cache`() {
+        cache.remove("not-there", 100)
+
+        assertEquals(1.0, removeCounter("missing"))
     }
 
     @Test

--- a/src/test/java/no/fintlabs/cache/FintCacheTest.kt
+++ b/src/test/java/no/fintlabs/cache/FintCacheTest.kt
@@ -1,5 +1,7 @@
 package no.fintlabs.cache
 
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
 import no.novari.fint.model.resource.utdanning.elev.ElevResource
 import org.junit.jupiter.api.BeforeEach
@@ -12,11 +14,21 @@ import kotlin.test.assertSame
 
 class FintCacheTest {
     private lateinit var cache: FintCache<ElevResource>
+    private lateinit var meterRegistry: MeterRegistry
 
     @BeforeEach
     fun setUp() {
-        cache = FintCache()
+        meterRegistry = SimpleMeterRegistry()
+        cache = FintCache("elev", meterRegistry)
     }
+
+    private fun putCounter(outcome: String): Double =
+        meterRegistry
+            .find("fint.consumer.cache.put")
+            .tag("resource", "elev")
+            .tag("outcome", outcome)
+            .counter()
+            ?.count() ?: 0.0
 
     @Test
     fun `cache size is empty when nothing is added`() {
@@ -52,6 +64,25 @@ class FintCacheTest {
         assertSame(elevAVersion4, cache.get(elevAVersion4.systemId.identifikatorverdi))
         assertSame(elevAVersion4, cache.getByIdField("brukernavn", elevAVersion4.brukernavn.identifikatorverdi))
         assertSame(elevAVersion4, cache.getByIdField("feidenavn", elevAVersion4.feidenavn.identifikatorverdi))
+    }
+
+    @Test
+    fun `put accepted counter increments on fresh write`() {
+        val elev = createElevResource("A")
+        cache.put(elev.systemId.identifikatorverdi, elev, 10)
+
+        assertEquals(1.0, putCounter("accepted"))
+        assertEquals(0.0, putCounter("rejected_stale"))
+    }
+
+    @Test
+    fun `put rejected_stale counter increments when timestamp is older than existing`() {
+        val elev = createElevResource("A")
+        cache.put(elev.systemId.identifikatorverdi, elev, 10)
+        cache.put(elev.systemId.identifikatorverdi, elev, 5)
+
+        assertEquals(1.0, putCounter("accepted"))
+        assertEquals(1.0, putCounter("rejected_stale"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Surfaces every silent-loss branch in the autorelation pipeline as Micrometer counters so production can quantify each failure mode without waiting for tests to catch it. Direct response to the `missing_back_link` class of defects (~0.14% of links in afk-no tenant).

**`fint.autorelation.buffer.records`** (counter, tags: resource, relation, outcome):
- `registered` / `appended` — normal buffering paths
- `drained` — links drained on target arrival
- `removed_by_delete` — buffered ADD cancelled by matching DELETE
- **`stillborn`** — ADD whose `timestamp` is already older than TTL, short-circuited out of the cache (B1 bug detector)
- `expired` — evicted by TTL via Caffeine `evictionListener` (synchronous)
- plus `fint.autorelation.buffer.size` gauge

**`fint.consumer.cache.{put,remove,evicted}`** (counters): accepted / rejected_stale / missing, and eviction count with cause=full_sync for `CacheEvictionService`.

**`fint.autorelation.apply`** (counter, per target-id): `applied` / `buffered` / `skipped_unknown_class` / `failed`.

**`fint.autorelation.reconcile`** (counter, per link): `preserved` / `hydrated` / `pruned`.

## Behaviour change (not just metrics)

`AutoRelationService.applyOrBufferUpdate` now wraps each target-id iteration in its own `try/catch`. Previously, if processing one target threw, Kotlin's `forEach` aborted and the remaining targets in the same M:M ADD were silently skipped. Now each failing target is counted (`skipped_unknown_class` or `failed`), logged with context, and the loop continues. This is a real silent-loss path that is now both observable and fixed.

`UnresolvedRelationCache.registerRelation` similarly short-circuits stale ADDs out of the cache entirely instead of letting Caffeine insert-and-immediately-evict them — the observable behaviour is the same, but metrics can see it.

## Dependency order

**This is PR 3 of 3. Merge PR #97, then PR #98, before this one.** GitHub auto-rebases as each parent merges.

1. #97 (`test/testcontainers-kafka-harness`) → `develop` ← merge first
2. #98 (`test/autorelation-integration-coverage`) → #97 branch ← merge second
3. **This PR** → #98 branch

## Test plan

- [ ] `./gradlew test` passes (unit)
- [ ] `./gradlew integrationTest` passes (no regressions from the behaviour change)
- [ ] Spot-check in a staging environment: verify Prometheus scrapes the new counters and gauges
- [ ] Before a real deploy, agree on a dashboard panel layout so the new signals are easy to watch during the next weekend sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)