### PR TITLE
feat: Testcontainers Kafka base IT and topic bootstrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     testImplementation 'org.awaitility:awaitility-kotlin:4.3.0'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/integrationTest/java/no/fintlabs/config/KafkaContainerBaseIT.kt
+++ b/src/integrationTest/java/no/fintlabs/config/KafkaContainerBaseIT.kt
@@ -1,0 +1,31 @@
+package no.fintlabs.config
+
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.kafka.ConfluentKafkaContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Starts a single [ConfluentKafkaContainer] per JVM, wires Spring's bootstrap-servers to it, and
+ * turns on `fint.consumer.kafka.bootstrap-topics` so `TopicBootstrapper` pre-creates the topics
+ * a consumer configured via `fint.consumer.{org-id,domain,package}` needs.
+ *
+ * Subclasses supply those three properties (usually via `@TestPropertySource`).
+ */
+abstract class KafkaContainerBaseIT {
+    companion object {
+        private const val IMAGE = "confluentinc/cp-kafka:7.8.0"
+
+        @JvmStatic
+        val KAFKA: ConfluentKafkaContainer =
+            ConfluentKafkaContainer(DockerImageName.parse(IMAGE)).apply { start() }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun kafkaProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.kafka.bootstrap-servers") { KAFKA.bootstrapServers }
+            registry.add("novari.kafka.default-replicas") { "1" }
+            registry.add("fint.consumer.kafka.bootstrap-topics") { "true" }
+        }
+    }
+}

--- a/src/integrationTest/java/no/fintlabs/config/KafkaContainerSmokeIT.kt
+++ b/src/integrationTest/java/no/fintlabs/config/KafkaContainerSmokeIT.kt
@@ -1,0 +1,87 @@
+package no.fintlabs.config
+
+import no.fintlabs.Application
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.TopicConfig
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = [Application::class])
+@TestPropertySource(
+    properties = [
+        "fint.org-id=fintlabs.no",
+        "fint.consumer.org-id=fintlabs.no",
+        "fint.consumer.domain=utdanning",
+        "fint.consumer.package=vurdering",
+    ],
+)
+class KafkaContainerSmokeIT : KafkaContainerBaseIT() {
+    private data class Expected(
+        val name: String,
+        val partitions: Int,
+        val retention: Duration,
+        val cleanupPolicy: String,
+    )
+
+    private val thirtyDays = Duration.ofDays(30)
+    private val sevenDays = Duration.ofDays(7)
+    private val compactDelete = "compact,delete"
+    private val delete = "delete"
+
+    private val expected =
+        listOf(
+            Expected("fintlabs-no.fint-core.entity.utdanning-vurdering", 6, thirtyDays, compactDelete),
+            Expected("fintlabs-no.fint-core.entity.utdanning-vurdering-relation-update", 6, thirtyDays, compactDelete),
+            Expected("fintlabs-no.fint-core.event.utdanning-vurdering-request", 1, sevenDays, delete),
+            Expected("fintlabs-no.fint-core.event.utdanning-vurdering-response", 1, sevenDays, delete),
+            Expected("fintlabs-no.fint-core.event.consumer-error", 1, sevenDays, delete),
+            Expected("fintlabs-no.fint-core.event.sync-status", 1, sevenDays, delete),
+        )
+
+    @Test
+    fun `container starts and topics are created with expected partitions and retention`() {
+        assertTrue(KAFKA.isRunning, "Kafka container should be running")
+
+        AdminClient
+            .create(mapOf(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG to KAFKA.bootstrapServers))
+            .use { admin ->
+                val names = expected.map { it.name }
+                val descriptions = admin.describeTopics(names).allTopicNames().get()
+                val configs =
+                    admin
+                        .describeConfigs(names.map { ConfigResource(ConfigResource.Type.TOPIC, it) })
+                        .all()
+                        .get()
+
+                expected.forEach { exp ->
+                    val desc = descriptions[exp.name] ?: error("Topic missing: ${exp.name}")
+                    assertEquals(exp.partitions, desc.partitions().size, "partitions for ${exp.name}")
+
+                    val topicConfig =
+                        configs[ConfigResource(ConfigResource.Type.TOPIC, exp.name)]
+                            ?: error("config missing for ${exp.name}")
+
+                    val retentionMs =
+                        topicConfig
+                            .get(TopicConfig.RETENTION_MS_CONFIG)
+                            ?.value()
+                            ?.toLong()
+                            ?: error("retention.ms missing for ${exp.name}")
+                    assertEquals(exp.retention.toMillis(), retentionMs, "retention for ${exp.name}")
+
+                    val cleanupPolicy =
+                        topicConfig
+                            .get(TopicConfig.CLEANUP_POLICY_CONFIG)
+                            ?.value()
+                            ?: error("cleanup.policy missing for ${exp.name}")
+                    assertEquals(exp.cleanupPolicy, cleanupPolicy, "cleanup.policy for ${exp.name}")
+                }
+            }
+    }
+}

--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -57,6 +57,8 @@ data class KafkaConfiguration(
     val requestConcurrency: Int = 1,
     // ResponseFintEvent
     val responseConcurrency: Int = 1,
+    // When true, create the consumer's default topics on startup (use for local dev + tests)
+    val bootstrapTopics: Boolean = false,
 )
 
 data class AutorelationConfig(

--- a/src/main/java/no/fintlabs/consumer/kafka/TopicBootstrapper.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/TopicBootstrapper.kt
@@ -1,0 +1,85 @@
+package no.fintlabs.consumer.kafka
+
+import jakarta.annotation.PostConstruct
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.config.OrgId
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.common.config.TopicConfig
+import org.apache.kafka.common.errors.TopicExistsException
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.concurrent.ExecutionException
+
+/**
+ * Creates the default topics a consumer needs so the service can start against an empty broker
+ * (local dev, integration tests). Disabled by default; enable with
+ * `fint.consumer.kafka.bootstrap-topics=true`.
+ */
+@Component
+@ConditionalOnProperty("fint.consumer.kafka.bootstrap-topics", havingValue = "true")
+class TopicBootstrapper(
+    private val consumerConfig: ConsumerConfiguration,
+    @param:Value("\${spring.kafka.bootstrap-servers}") private val bootstrapServers: String,
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    @PostConstruct
+    fun createTopics() {
+        val topics = buildTopics()
+        logger.info("Bootstrapping {} topics on {}: {}", topics.size, bootstrapServers, topics)
+
+        val adminProps = mapOf(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers)
+        AdminClient.create(adminProps).use { admin ->
+            try {
+                admin.createTopics(topics.map { it.toNewTopic() }).all().get()
+            } catch (e: ExecutionException) {
+                if (e.cause !is TopicExistsException) throw e
+            }
+        }
+    }
+
+    private fun buildTopics(): List<TopicSpec> {
+        val prefix = "${consumerConfig.orgId.asTopicSegment}.$DOMAIN_CONTEXT"
+        val fintlabsPrefix = "${FINTLABS.asTopicSegment}.$DOMAIN_CONTEXT"
+        val resource = "${consumerConfig.domain}-${consumerConfig.packageName}"
+        val entity30d = { name: String -> TopicSpec(name, 6, Duration.ofDays(30), COMPACT_DELETE) }
+        val event7d = { name: String -> TopicSpec(name, 1, Duration.ofDays(7), DELETE) }
+        return listOf(
+            entity30d("$prefix.entity.$resource"),
+            entity30d("$prefix.entity.$resource-relation-update"),
+            event7d("$prefix.event.$resource-request"),
+            event7d("$prefix.event.$resource-response"),
+            event7d("$fintlabsPrefix.event.consumer-error"),
+            event7d("$fintlabsPrefix.event.sync-status"),
+        )
+    }
+
+    private fun TopicSpec.toNewTopic(): NewTopic =
+        NewTopic(name, partitions, REPLICAS)
+            .configs(
+                mapOf(
+                    TopicConfig.RETENTION_MS_CONFIG to retention.toMillis().toString(),
+                    TopicConfig.CLEANUP_POLICY_CONFIG to cleanupPolicy,
+                ),
+            )
+
+    private data class TopicSpec(
+        val name: String,
+        val partitions: Int,
+        val retention: Duration,
+        val cleanupPolicy: String,
+    )
+
+    companion object {
+        private const val DOMAIN_CONTEXT = "fint-core"
+        private const val REPLICAS: Short = 1
+        private const val COMPACT_DELETE = "${TopicConfig.CLEANUP_POLICY_COMPACT},${TopicConfig.CLEANUP_POLICY_DELETE}"
+        private const val DELETE: String = TopicConfig.CLEANUP_POLICY_DELETE
+        private val FINTLABS = OrgId.from("fintlabs.no")
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -14,6 +14,8 @@ fint:
     package: vurdering
     packageName: ${fint.consumer.package}
     org-id: fintlabs.no
+    kafka:
+      bootstrap-topics: true
 
 novari:
   kafka:


### PR DESCRIPTION
## Summary
- Adds `TopicBootstrapper` in main src, gated by `fint.consumer.kafka.bootstrap-topics`, which pre-creates the consumer's default topics at startup (entity + relation-update: 6 partitions, 30d retention, `compact,delete`; request/response/consumer-error/sync-status: 1 partition, 7d retention, `delete`).
- Enables it in `application-local.yaml` so the service boots against an empty local broker.
- Adds `KafkaContainerBaseIT` which starts a JVM-singleton `ConfluentKafkaContainer` and flips the bootstrap flag on so integration tests share the same topic-creation code path.
- Adds `KafkaContainerSmokeIT` asserting all six topics exist with the expected partition and cleanup config.

Existing `@EmbeddedKafka` ITs are untouched — migration can happen incrementally.