### PR TITLE
feat: jitter Kafka listener startup to smooth broker load

### DIFF
--- a/src/integrationTest/resources/application.yaml
+++ b/src/integrationTest/resources/application.yaml
@@ -19,6 +19,7 @@ fint:
       fetchMinBytes: 1
       fetchMaxWaitMs: 50
       idleBetweenPolls: 0
+      startup-jitter: 0s
 
 novari:
   kafka:

--- a/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/AutoRelationEntityConsumer.kt
@@ -5,6 +5,7 @@ import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
 import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
+import no.fintlabs.consumer.kafka.applyStartupJitter
 import no.fintlabs.consumer.kafka.entity.extractIdentifier
 import no.fintlabs.consumer.kafka.stringValue
 import no.novari.kafka.consuming.ErrorHandlerFactory
@@ -65,6 +66,7 @@ class AutoRelationEntityConsumer(
                     container.concurrency = consumerConfig.kafka.entityConcurrency
                     container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                     container.applyConsumerFetchSettings(consumerConfig.kafka)
+                    container.applyStartupJitter(consumerConfig.kafka)
                 },
             ).createContainer(
                 EntityTopicNameParameters

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -6,6 +6,7 @@ import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
 import no.fintlabs.consumer.kafka.KafkaThroughputMetrics
 import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
+import no.fintlabs.consumer.kafka.applyStartupJitter
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.consuming.ParameterizedListenerContainerFactoryService
@@ -61,6 +62,7 @@ class RelationUpdateConsumer(
                     container.concurrency = consumerConfig.kafka.relationConcurrency
                     container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                     container.applyConsumerFetchSettings(consumerConfig.kafka)
+                    container.applyStartupJitter(consumerConfig.kafka)
                 },
             ).createContainer(
                 EntityTopicNamePatternParameters

--- a/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
+++ b/src/main/java/no/fintlabs/consumer/config/ConsumerConfiguration.kt
@@ -59,6 +59,10 @@ data class KafkaConfiguration(
     val responseConcurrency: Int = 1,
     // When true, create the consumer's default topics on startup (use for local dev + tests)
     val bootstrapTopics: Boolean = false,
+    // Upper bound of uniformly-random per-pod delay before Kafka listeners start consuming.
+    // Spreads initial fetch/replay load across many simultaneously-starting services.
+    // Set to Duration.ZERO (e.g. in local/test configs) to start listeners immediately.
+    val startupJitter: Duration = Duration.ofMinutes(3),
 )
 
 data class AutorelationConfig(

--- a/src/main/java/no/fintlabs/consumer/kafka/KafkaContainerCustomizer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/KafkaContainerCustomizer.kt
@@ -16,3 +16,11 @@ fun <VALUE> ConcurrentMessageListenerContainer<String, VALUE>.applyConsumerFetch
         kafkaConfiguration.fetchMaxWaitMs.toString(),
     )
 }
+
+fun <VALUE> ConcurrentMessageListenerContainer<String, VALUE>.applyStartupJitter(
+    kafkaConfiguration: KafkaConfiguration,
+) {
+    if (!kafkaConfiguration.startupJitter.isZero) {
+        isAutoStartup = false
+    }
+}

--- a/src/main/java/no/fintlabs/consumer/kafka/KafkaListenerStartupJitter.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/KafkaListenerStartupJitter.kt
@@ -1,0 +1,51 @@
+package no.fintlabs.consumer.kafka
+
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationContext
+import org.springframework.context.event.EventListener
+import org.springframework.kafka.listener.MessageListenerContainer
+import org.springframework.stereotype.Component
+import java.util.concurrent.ThreadLocalRandom
+
+@Component
+class KafkaListenerStartupJitter(
+    private val consumerConfig: ConsumerConfiguration,
+    private val applicationContext: ApplicationContext,
+) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(KafkaListenerStartupJitter::class.java)
+    }
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun startListenersAfterJitter() {
+        val jitter = consumerConfig.kafka.startupJitter
+        if (jitter.isZero) return
+
+        val containers = applicationContext.getBeansOfType(MessageListenerContainer::class.java).values
+        val delayMs = ThreadLocalRandom.current().nextLong(jitter.toMillis() + 1)
+
+        logger.info(
+            "Delaying Kafka listener startup by {} ms (max jitter {} ms) across {} containers",
+            delayMs,
+            jitter.toMillis(),
+            containers.size,
+        )
+
+        Thread.ofVirtual().name("kafka-startup-jitter").start {
+            try {
+                Thread.sleep(delayMs)
+            } catch (ex: InterruptedException) {
+                Thread.currentThread().interrupt()
+                logger.warn("Kafka startup jitter interrupted; starting containers immediately")
+            }
+            containers.forEach { container ->
+                if (!container.isRunning) {
+                    logger.info("Starting Kafka listener container: {}", container.listenerId ?: container)
+                    container.start()
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityConsumer.kt
@@ -4,6 +4,7 @@ import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConstants.RESOURCE_NAME
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
 import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
+import no.fintlabs.consumer.kafka.applyStartupJitter
 import no.fintlabs.consumer.kafka.stringValue
 import no.fintlabs.consumer.resource.ResourceConverter
 import no.novari.kafka.consuming.ErrorHandlerFactory
@@ -57,6 +58,7 @@ class EntityConsumer(
                     container.concurrency = consumerConfig.kafka.entityConcurrency
                     container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                     container.applyConsumerFetchSettings(consumerConfig.kafka)
+                    container.applyStartupJitter(consumerConfig.kafka)
                 },
             ).createContainer(
                 EntityTopicNamePatternParameters

--- a/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/EventResponseConsumer.kt
@@ -4,6 +4,7 @@ import no.fintlabs.adapter.models.event.ResponseFintEvent
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
 import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
+import no.fintlabs.consumer.kafka.applyStartupJitter
 import no.fintlabs.consumer.resource.event.EventStatusCache
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
@@ -47,6 +48,7 @@ class EventResponseConsumer(
                     container.concurrency = consumerConfig.kafka.responseConcurrency
                     container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                     container.applyConsumerFetchSettings(consumerConfig.kafka)
+                    container.applyStartupJitter(consumerConfig.kafka)
                 },
             ).createContainer(
                 EventTopicNameParameters

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventConsumer.kt
@@ -4,6 +4,7 @@ import no.fintlabs.adapter.models.event.RequestFintEvent
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.kafka.KafkaConsumerErrorHandling
 import no.fintlabs.consumer.kafka.applyConsumerFetchSettings
+import no.fintlabs.consumer.kafka.applyStartupJitter
 import no.fintlabs.consumer.resource.event.EventStatusCache
 import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
@@ -52,6 +53,7 @@ class RequestFintEventConsumer(
                     container.concurrency = consumerConfig.kafka.requestConcurrency
                     container.containerProperties.idleBetweenPolls = consumerConfig.kafka.idleBetweenPolls
                     container.applyConsumerFetchSettings(consumerConfig.kafka)
+                    container.applyStartupJitter(consumerConfig.kafka)
                 },
             ).createContainer(
                 EventTopicNameParameters

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -16,6 +16,7 @@ fint:
     org-id: fintlabs.no
     kafka:
       bootstrap-topics: true
+      startup-jitter: 0s
 
 novari:
   kafka:


### PR DESCRIPTION
Adds a configurable per-pod random delay (default 3 minutes) applied before Kafka listener containers start consuming. Spreads the initial fetch/replay spike across many simultaneously-starting services while staying within typical startup SLAs.

Local dev and integration-test profiles override the jitter to zero to preserve immediate startup.