### PR TITLE
feat: add loss-tracking metrics for autorelation flow

### DIFF
--- a/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
+++ b/src/main/java/no/fintlabs/autorelation/AutoRelationService.kt
@@ -3,6 +3,8 @@ package no.fintlabs.autorelation
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.fintlabs.autorelation.buffer.UnresolvedRelationCache
 import no.fintlabs.autorelation.cache.RelationRuleRegistry
+import no.fintlabs.autorelation.model.AutoRelationException
+import no.fintlabs.autorelation.model.MetricReason
 import no.fintlabs.autorelation.model.RelationOperation
 import no.fintlabs.autorelation.model.RelationSyncRule
 import no.fintlabs.autorelation.model.RelationUpdate
@@ -12,6 +14,7 @@ import no.fintlabs.consumer.links.LinkService
 import no.fintlabs.consumer.resource.ResourceLockService
 import no.fintlabs.consumer.resource.context.ResourceContext
 import no.novari.fint.model.resource.FintResource
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -25,23 +28,52 @@ class AutoRelationService(
     private val resourceContext: ResourceContext,
     private val objectMapper: ObjectMapper,
     private val resourceLockService: ResourceLockService,
+    private val metricService: MetricService,
 ) {
-    fun applyOrBufferUpdate(relationUpdate: RelationUpdate) =
-        relationUpdate.targetIds.forEach { id ->
-            resourceLockService.withLock(relationUpdate.targetEntity.resourceName, id) {
-                val resource = getResourceFromCache(relationUpdate.targetEntity.resourceName, id)
+    fun process(relationUpdate: RelationUpdate) =
+        relationUpdate.targetIds.forEach { resourceId ->
+            resourceLockService.withLock(relationUpdate.targetEntity.resourceName, resourceId) {
+                val existingResource = getResourceFromCache(relationUpdate.targetEntity.resourceName, resourceId)
 
-                if (resource != null) {
-                    // TODO: Deep copy through JSON serialization + deserialization is a super resource intensive anti-pattern
-                    val resourceCopy = resource.deepCopy(objectMapper, relationUpdate.getResourceClass())
-                    resourceCopy.applyUpdate(relationUpdate)
-                    linkService.mapLinks(relationUpdate.targetEntity.resourceName, resourceCopy)
-                    putInCache(relationUpdate, id, resourceCopy)
+                if (existingResource != null) {
+                    relationUpdate.apply(existingResource, resourceId)
                 } else {
-                    relationUpdate.bufferRelation(id)
+                    relationUpdate.buffer(resourceId)
                 }
             }
         }
+
+    private fun RelationUpdate.apply(
+        existingResource: FintResource,
+        resourceId: String,
+    ) = try {
+        val resourceCopy = existingResource.deepCopy(objectMapper, getResourceClass())
+        resourceCopy.applyUpdate(this)
+        linkService.mapLinks(targetEntity.resourceName, resourceCopy)
+        putInCache(this, resourceId, resourceCopy)
+        metricService.incrementUpdateApplied(targetEntity.resourceName, operation)
+    } catch (e: AutoRelationException) {
+        metricService.incrementUpdateFailed(targetEntity.resourceName, operation, e.metricReason)
+        logger.warn(
+            "Failed to apply relation update for '{}' ({}). Reason: {}",
+            targetEntity.resourceName,
+            resourceId,
+            e.metricReason.tagValue,
+            e,
+        )
+    } catch (e: Exception) {
+        metricService.incrementUpdateFailed(
+            targetEntity.resourceName,
+            operation,
+            MetricReason.UNEXPECTED_ERROR,
+        )
+        logger.error(
+            "Unexpected error applying relation update for '{}' ({})",
+            targetEntity.resourceName,
+            resourceId,
+            e,
+        )
+    }
 
     /**
      * Main reconciliation entry point.
@@ -65,7 +97,7 @@ class AutoRelationService(
             .getInverseRelations(consumerConfig.domain, consumerConfig.packageName, resourceName)
             .filter { it !in managedRelationNames } // Safety net
             .forEach { relation ->
-                fintResource.preserveExistingLinks(oldResource, relation)
+                fintResource.preserveExistingLinks(oldResource, resourceName, relation)
                 fintResource.applyPendingLinks(resourceName, resourceId, relation)
             }
     }
@@ -98,8 +130,12 @@ class AutoRelationService(
 
     private fun FintResource.preserveExistingLinks(
         oldResource: FintResource?,
+        resourceName: String,
         relation: String,
     ) = oldResource?.links?.get(relation)?.let { oldLinks ->
+        if (oldLinks.isNotEmpty()) {
+            metricService.incrementPreservedLinks(resourceName, relation, oldLinks.size)
+        }
         this.addUniqueLinks(relation, oldLinks)
     }
 
@@ -109,9 +145,14 @@ class AutoRelationService(
         relationName: String,
     ) = unresolvedRelationCache
         .takeRelations(resourceName, resourceId, relationName)
-        .let { linksToAttach -> addUniqueLinks(relationName, linksToAttach) }
+        .let { linksToAttach ->
+            if (linksToAttach.isNotEmpty()) {
+                metricService.incrementHydratedLinks(resourceName, relationName, linksToAttach.size)
+            }
+            addUniqueLinks(relationName, linksToAttach)
+        }
 
-    private fun RelationUpdate.bufferRelation(id: String) =
+    private fun RelationUpdate.buffer(id: String) {
         with(binding) {
             when (operation) {
                 RelationOperation.ADD -> {
@@ -134,6 +175,8 @@ class AutoRelationService(
                 }
             }
         }
+        metricService.incrementUpdateBuffered(targetEntity.resourceName, operation)
+    }
 
     private fun getResourceFromCache(
         resource: String,
@@ -150,9 +193,15 @@ class AutoRelationService(
     ) {
         val cache = cacheService.getCache(relationUpdate.targetEntity.resourceName)
         val timestamp = maxOf(relationUpdate.timestamp, cache.lastUpdatedByResourceId(id) ?: 0L)
-        cache.put(id, resource, timestamp)
+        if (!cache.put(id, resource, timestamp)) {
+            metricService.incrementCachePutRejectedOlderTimestamp(relationUpdate.targetEntity.resourceName)
+        }
     }
 
     // use !! to fail-fast if an unknown resource enters the system
     private fun RelationUpdate.getResourceClass() = resourceContext.getResource(targetEntity.resourceName)!!.clazz
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(AutoRelationService::class.java)
+    }
 }

--- a/src/main/java/no/fintlabs/autorelation/FintResourceExtensions.kt
+++ b/src/main/java/no/fintlabs/autorelation/FintResourceExtensions.kt
@@ -1,21 +1,28 @@
 package no.fintlabs.autorelation
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import no.fintlabs.autorelation.model.DeepCopyException
 import no.fintlabs.autorelation.model.RelationOperation
 import no.fintlabs.autorelation.model.RelationUpdate
 import no.novari.fint.model.resource.FintResource
 import no.novari.fint.model.resource.Link
 
+// TODO: Deep copy through JSON serialization + deserialization is a super resource intensive anti-pattern
+
 /**
  * Creates a complete deep copy of the FintResource using an explicitly provided target class.
+ *
+ * @throws DeepCopyException if Jackson serialization or deserialization fails.
  */
 fun <T : FintResource> FintResource.deepCopy(
     objectMapper: ObjectMapper,
     clazz: Class<T>,
 ): T =
-    objectMapper
-        .writeValueAsBytes(this)
-        .let { objectMapper.readValue(it, clazz) }
+    runCatching {
+        objectMapper
+            .writeValueAsBytes(this)
+            .let { objectMapper.readValue(it, clazz) }
+    }.getOrElse { throw DeepCopyException(clazz, it) }
 
 /**
  * Compares [this] (new resource) with [oldResource] and returns a map of

--- a/src/main/java/no/fintlabs/autorelation/MetricService.kt
+++ b/src/main/java/no/fintlabs/autorelation/MetricService.kt
@@ -1,30 +1,121 @@
 package no.fintlabs.autorelation
 
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import no.fintlabs.autorelation.model.MetricReason
+import no.fintlabs.autorelation.model.RelationOperation
 import org.springframework.stereotype.Service
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
 class MetricService(
     private val meterRegistry: MeterRegistry,
 ) {
-    fun incrementRelationSuccess(resourceName: String) =
-        meterRegistry
-            .counter(
-                "fint.autorelation.processed.success",
-                listOf(Tag.of("resource_name", resourceName)),
-            ).increment()
+    private val counters = ConcurrentHashMap<String, Counter>()
 
-    fun incrementRelationFailure(
+    fun incrementRuleSkipped(
         resourceName: String,
         reason: MetricReason,
-    ) = meterRegistry
-        .counter(
-            "fint.autorelation.processed.failure",
-            listOf(
-                Tag.of("resource_name", resourceName),
-                Tag.of("reason", reason.tagValue),
-            ),
+    ) = counter(
+        "fint.autorelation.rule.skipped",
+        listOf(
+            Tag.of("resource", resourceName),
+            Tag.of("reason", reason.tagValue),
+        ),
+    ).increment()
+
+    fun incrementUpdateApplied(
+        resourceName: String,
+        operation: RelationOperation,
+    ) = counter(
+        "fint.autorelation.update.applied",
+        listOf(
+            Tag.of("resource", resourceName),
+            Tag.of("operation", operation.tagValue),
+        ),
+    ).increment()
+
+    fun incrementUpdateBuffered(
+        resourceName: String,
+        operation: RelationOperation,
+    ) = counter(
+        "fint.autorelation.update.buffered",
+        listOf(
+            Tag.of("resource", resourceName),
+            Tag.of("operation", operation.tagValue),
+        ),
+    ).increment()
+
+    fun incrementUpdateFailed(
+        resourceName: String,
+        operation: RelationOperation,
+        reason: MetricReason,
+    ) = counter(
+        "fint.autorelation.update.failed",
+        listOf(
+            Tag.of("resource", resourceName),
+            Tag.of("operation", operation.tagValue),
+            Tag.of("reason", reason.tagValue),
+        ),
+    ).increment()
+
+    fun incrementBufferExpired(
+        resourceName: String,
+        relationName: String,
+        linkCount: Int,
+    ) = counter(
+        "fint.autorelation.buffer.expired",
+        listOf(
+            Tag.of("resource", resourceName),
+            Tag.of("relation", relationName),
+        ),
+    ).increment(linkCount.toDouble())
+
+    fun incrementHydratedLinks(
+        resourceName: String,
+        relationName: String,
+        linkCount: Int,
+    ) = counter(
+        "fint.autorelation.reconcile.hydrated_links",
+        listOf(
+            Tag.of("resource", resourceName),
+            Tag.of("relation", relationName),
+        ),
+    ).increment(linkCount.toDouble())
+
+    fun incrementPreservedLinks(
+        resourceName: String,
+        relationName: String,
+        linkCount: Int,
+    ) = counter(
+        "fint.autorelation.reconcile.preserved_links",
+        listOf(
+            Tag.of("resource", resourceName),
+            Tag.of("relation", relationName),
+        ),
+    ).increment(linkCount.toDouble())
+
+    fun registerBufferSizeGauge(supplier: () -> Number): Gauge =
+        Gauge
+            .builder("fint.autorelation.buffer.size", supplier)
+            .description("Current number of buffered relation keys awaiting target arrival")
+            .register(meterRegistry)
+
+    fun incrementCachePutRejectedOlderTimestamp(resourceName: String) =
+        counter(
+            "fint.consumer.cache.put_rejected_older_timestamp",
+            listOf(Tag.of("resource", resourceName)),
         ).increment()
+
+    private fun counter(
+        name: String,
+        tags: List<Tag>,
+    ): Counter = counters.computeIfAbsent(meterKey(name, tags)) { meterRegistry.counter(name, tags) }
+
+    private fun meterKey(
+        name: String,
+        tags: List<Tag>,
+    ): String = "$name|${tags.joinToString("|") { "${it.key}=${it.value}" }}"
 }

--- a/src/main/java/no/fintlabs/autorelation/RelationEventService.kt
+++ b/src/main/java/no/fintlabs/autorelation/RelationEventService.kt
@@ -76,9 +76,12 @@ class RelationEventService(
         resourceId: String,
         operation: RelationOperation,
     ) = rules.forEach { rule ->
-        publish(resourceName, resourceId) {
-            rule.toRelationUpdate(resource, resourceId, operation)?.let {
-                relationUpdateProducer.publishRelationUpdate(it, resourceName, resourceId)
+        publish(resourceName, resourceId, rule.targetRelation) {
+            val update = rule.toRelationUpdate(resource, resourceId, operation)
+            if (update == null) {
+                metricService.incrementRuleSkipped(resourceName, MetricReason.NO_TARGETS)
+            } else {
+                relationUpdateProducer.publishRelationUpdate(update, resourceName, resourceId)
             }
         }
     }
@@ -89,10 +92,9 @@ class RelationEventService(
         relationName: String? = null,
         block: () -> Unit,
     ) = runCatching(block)
-        .onSuccess { metricService.incrementRelationSuccess(resourceName) }
         .onFailure { error ->
             val reason = error.toMetricReason()
-            metricService.incrementRelationFailure(resourceName, reason)
+            metricService.incrementRuleSkipped(resourceName, reason)
             logRelationError(error, resourceName, resourceId, reason, relationName)
         }
 
@@ -103,7 +105,7 @@ class RelationEventService(
     ): FintResource? =
         runCatching { resourceConverter.convert(resourceName, resource) }
             .onFailure {
-                metricService.incrementRelationFailure(resourceName, MetricReason.CONVERSION_FAILED)
+                metricService.incrementRuleSkipped(resourceName, MetricReason.CONVERSION_FAILED)
                 logRelationError(it, resourceName, resourceId, MetricReason.CONVERSION_FAILED)
             }.getOrNull()
 

--- a/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
+++ b/src/main/java/no/fintlabs/autorelation/buffer/UnresolvedRelationCache.kt
@@ -3,6 +3,8 @@ package no.fintlabs.autorelation.buffer
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.Expiry
+import com.github.benmanes.caffeine.cache.RemovalCause
+import no.fintlabs.autorelation.MetricService
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.novari.fint.model.resource.Link
 import org.springframework.stereotype.Component
@@ -18,9 +20,22 @@ data class TimestampedLinks(
 @Component
 class UnresolvedRelationCache(
     consumerConfiguration: ConsumerConfiguration,
+    private val metricService: MetricService,
 ) {
     private val cache: Cache<RelationKey, TimestampedLinks> =
-        buildRelationCache(consumerConfiguration.autorelation.buffer.ttl)
+        buildRelationCache(consumerConfiguration.autorelation.buffer.ttl) { key, value, cause ->
+            if (cause == RemovalCause.EXPIRED && key != null && value != null) {
+                metricService.incrementBufferExpired(
+                    key.resource,
+                    key.relation,
+                    value.links.size,
+                )
+            }
+        }
+
+    init {
+        metricService.registerBufferSizeGauge { cache.estimatedSize() }
+    }
 
     fun takeRelations(
         resourceName: String,
@@ -71,7 +86,10 @@ class UnresolvedRelationCache(
     fun cleanUp() = cache.cleanUp()
 }
 
-private fun buildRelationCache(ttl: Duration): Cache<RelationKey, TimestampedLinks> =
+private fun buildRelationCache(
+    ttl: Duration,
+    onRemoval: (RelationKey?, TimestampedLinks?, RemovalCause) -> Unit,
+): Cache<RelationKey, TimestampedLinks> =
     Caffeine
         .newBuilder()
         .expireAfter(
@@ -99,4 +117,5 @@ private fun buildRelationCache(ttl: Duration): Cache<RelationKey, TimestampedLin
                     currentDuration: Long,
                 ): Long = currentDuration
             },
-        ).build()
+        ).removalListener(onRemoval)
+        .build()

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateConsumer.kt
@@ -84,40 +84,10 @@ class RelationUpdateConsumer(
     fun consumeRecord(consumerRecord: ConsumerRecord<String?, RelationUpdate>) {
         val startedAt = System.nanoTime()
         val relationUpdate = consumerRecord.value()
-
-        if (relationUpdate == null) {
-            kafkaThroughputMetrics.recordRelationUpdateConsumer(null, "ignored_null", System.nanoTime() - startedAt)
-            return
-        }
-
-        if (!relationUpdate.belongsToThisService()) {
-            kafkaThroughputMetrics.recordRelationUpdateConsumer(
-                relationUpdate.targetEntity.resourceName,
-                "ignored_foreign_component",
-                System.nanoTime() - startedAt,
-            )
-            return
-        }
-
-        try {
-            autoRelationService.applyOrBufferUpdate(relationUpdate)
-            kafkaThroughputMetrics.recordRelationUpdateConsumer(
-                relationUpdate.targetEntity.resourceName,
-                "processed",
-                System.nanoTime() - startedAt,
-            )
-        } catch (ex: Exception) {
-            kafkaThroughputMetrics.recordRelationUpdateConsumer(
-                relationUpdate.targetEntity.resourceName,
-                "failed",
-                System.nanoTime() - startedAt,
-            )
-            throw ex
-        }
+        autoRelationService.process(relationUpdate)
+        kafkaThroughputMetrics.recordRelationUpdateConsumer(
+            relationUpdate.targetEntity.resourceName,
+            System.nanoTime() - startedAt,
+        )
     }
-
-    private fun RelationUpdate.belongsToThisService() =
-        with(targetEntity) {
-            consumerConfig.matchesComponent(domainName, packageName)
-        }
 }

--- a/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateProducer.kt
+++ b/src/main/java/no/fintlabs/autorelation/kafka/RelationUpdateProducer.kt
@@ -26,7 +26,6 @@ class RelationUpdateProducer(
     ): CompletableFuture<SendResult<String, RelationUpdate>> {
         val targetEntity = relationUpdate.targetEntity
         val operation = relationUpdate.operation.name
-        kafkaThroughputMetrics.recordRelationUpdateProduced(targetEntity.resourceName, operation, "attempted")
 
         val result =
             entityProducer.send(

--- a/src/main/java/no/fintlabs/autorelation/model/AutoRelationException.kt
+++ b/src/main/java/no/fintlabs/autorelation/model/AutoRelationException.kt
@@ -30,10 +30,21 @@ class KafkaPublishException(
     cause: Throwable? = null,
 ) : AutoRelationException("Kafka publish failed for: $message", MetricReason.KAFKA_PUBLISH_ERROR, cause)
 
+class DeepCopyException(
+    targetClass: Class<*>,
+    cause: Throwable,
+) : AutoRelationException(
+        "Deep copy failed for class '${targetClass.simpleName}'",
+        MetricReason.DEEP_COPY_FAILED,
+        cause,
+    )
+
 enum class MetricReason(
     val tagValue: String,
 ) {
+    NO_TARGETS("no_targets"),
     CONVERSION_FAILED("conversion_failed"),
+    DEEP_COPY_FAILED("deep_copy_failed"),
     MISSING_MANDATORY_LINK("missing_mandatory_link"),
     INVALID_LINK("invalid_link"),
     VALIDATION_ID_MISMATCH("validation_id_mismatch"),

--- a/src/main/java/no/fintlabs/autorelation/model/RelationOperation.kt
+++ b/src/main/java/no/fintlabs/autorelation/model/RelationOperation.kt
@@ -3,4 +3,8 @@ package no.fintlabs.autorelation.model
 enum class RelationOperation {
     ADD,
     DELETE,
+    ;
+
+    val tagValue: String
+        get() = name.lowercase()
 }

--- a/src/main/java/no/fintlabs/cache/FintCache.kt
+++ b/src/main/java/no/fintlabs/cache/FintCache.kt
@@ -86,18 +86,22 @@ class FintCache<T : FintResource> {
      * When replacing an existing entry the old [SortKey] is removed from [sortedEntries]
      * before inserting the new one, so the sorted view always reflects the current timestamp.
      * Updates the identifier index and advances [lastUpdated] with the provided timestamp.
+     *
+     * @return `true` if the write was accepted, `false` if it was rejected because an existing
+     *   entry has a newer timestamp. A `false` return is a silent-loss signal callers may surface
+     *   via a metric; callers that don't care can ignore it.
      */
     fun put(
         resourceId: String,
         resource: T,
         timestamp: Long,
-    ) {
+    ): Boolean {
         val entry = CacheEntry(resource, timestamp)
 
-        lock.write {
+        return lock.write {
             val existing = entryStore[resourceId]
             if (existing != null) {
-                if (timestamp < existing.timestamp) return@write
+                if (timestamp < existing.timestamp) return@write false
                 sortedEntries.remove(SortKey(existing.timestamp, resourceId))
                 removeFromIndexes(existing.resource)
             }
@@ -105,6 +109,7 @@ class FintCache<T : FintResource> {
             sortedEntries[SortKey(timestamp, resourceId)] = entry
             updateIndexes(entry)
             lastUpdated = timestamp
+            true
         }
     }
 

--- a/src/main/java/no/fintlabs/consumer/kafka/KafkaThroughputMetrics.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/KafkaThroughputMetrics.kt
@@ -8,6 +8,20 @@ import org.springframework.stereotype.Service
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
+/**
+ * Transport-level Kafka throughput metrics for the relation-update flow.
+ *
+ * These metrics measure what happens at the Kafka boundary: how many records the producer
+ * sent, how many the consumer pulled in, and how long each took to process. Per-target
+ * business outcomes (applied / buffered / failed-with-reason) live in
+ * [no.fintlabs.autorelation.MetricService] instead, since one consumed record fans out to
+ * N targets and each target has its own outcome.
+ *
+ * The intended debugging shape is to join across the two: comparing
+ * `relation_update.produced{outcome="published"}` against the sum of `update.applied`,
+ * `update.buffered`, and `update.failed` per resource surfaces "where did relation
+ * updates disappear" between the producer and the per-target verdict.
+ */
 @Service
 class KafkaThroughputMetrics(
     private val meterRegistry: MeterRegistry,
@@ -15,51 +29,33 @@ class KafkaThroughputMetrics(
     private val counters = ConcurrentHashMap<String, Counter>()
     private val timers = ConcurrentHashMap<String, Timer>()
 
-    fun recordEntityConsumer(
-        resourceName: String,
-        outcome: String,
-        durationNs: Long,
-    ) {
-        val tags =
-            listOf(
-                Tag.of("resource", normalizeResource(resourceName)),
-                Tag.of("outcome", outcome),
-            )
-        counter("fint.consumer.kafka.entity.records", tags).increment()
-        timer("fint.consumer.kafka.entity.processing.duration", tags).record(durationNs, TimeUnit.NANOSECONDS)
-    }
-
-    fun recordAutoRelationEntityConsumer(
-        resourceName: String,
-        outcome: String,
-        durationNs: Long,
-    ) {
-        val tags =
-            listOf(
-                Tag.of("resource", normalizeResource(resourceName)),
-                Tag.of("outcome", outcome),
-            )
-        counter("fint.consumer.kafka.autorelation_entity.records", tags).increment()
-        timer(
-            "fint.consumer.kafka.autorelation_entity.processing.duration",
-            tags,
-        ).record(durationNs, TimeUnit.NANOSECONDS)
-    }
-
+    /**
+     * Records a consumed relation-update record: increments the records counter and
+     * records the processing duration.
+     *
+     * Tagged by [targetResource] only — outcome is intentionally omitted because the
+     * consumer call swallows per-target failures internally (see
+     * [no.fintlabs.autorelation.AutoRelationService]), so a single record-level
+     * success/failed tag would be misleading. Per-target outcomes live in
+     * [no.fintlabs.autorelation.MetricService].
+     */
     fun recordRelationUpdateConsumer(
         targetResource: String?,
-        outcome: String,
         durationNs: Long,
     ) {
-        val tags =
-            listOf(
-                Tag.of("resource", normalizeResource(targetResource)),
-                Tag.of("outcome", outcome),
-            )
+        val tags = listOf(Tag.of("resource", normalizeResource(targetResource)))
         counter("fint.consumer.kafka.relation_update.records", tags).increment()
         timer("fint.consumer.kafka.relation_update.processing.duration", tags).record(durationNs, TimeUnit.NANOSECONDS)
     }
 
+    /**
+     * Records a produced relation-update from the producer side, tagged by
+     * [targetResource], [operation] (`add` / `delete`), and [outcome]
+     * (`published` / `failed`).
+     *
+     * Pairs with [recordRelationUpdateConsumer] for the produced-vs-consumed diff that
+     * shows whether records reach the consumer at all.
+     */
     fun recordRelationUpdateProduced(
         targetResource: String?,
         operation: String,

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityProcessingService.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityProcessingService.kt
@@ -3,6 +3,7 @@ package no.fintlabs.consumer.kafka.entity
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import no.fintlabs.autorelation.AutoRelationService
+import no.fintlabs.autorelation.MetricService
 import no.fintlabs.autorelation.RelationEventService
 import no.fintlabs.cache.CacheService
 import no.fintlabs.consumer.config.ConsumerConfiguration
@@ -23,6 +24,7 @@ class EntityProcessingService(
     private val syncTrackerService: SyncTrackerService,
     private val meterRegistry: MeterRegistry,
     private val resourceLockService: ResourceLockService,
+    private val metricService: MetricService,
 ) {
     fun processEntityConsumerRecord(record: EntityConsumerRecord) {
         val resourceName = record.resourceName
@@ -82,8 +84,12 @@ class EntityProcessingService(
         timed(record.resourceName, "links.map") {
             linkService.mapLinks(record.resourceName, resource)
         }
-        timed(record.resourceName, "cache.put") {
-            cache.put(record.key, resource, record.timestamp)
+        val accepted =
+            timed(record.resourceName, "cache.put") {
+                cache.put(record.key, resource, record.timestamp)
+            }
+        if (!accepted) {
+            metricService.incrementCachePutRejectedOlderTimestamp(record.resourceName)
         }
     }
 

--- a/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/AutoRelationServiceTest.kt
@@ -10,6 +10,8 @@ import io.mockk.verify
 import no.fintlabs.autorelation.buffer.UnresolvedRelationCache
 import no.fintlabs.autorelation.cache.RelationRuleRegistry
 import no.fintlabs.autorelation.model.EntityDescriptor
+import no.fintlabs.autorelation.model.InvalidLinkException
+import no.fintlabs.autorelation.model.MetricReason
 import no.fintlabs.autorelation.model.RelationBinding
 import no.fintlabs.autorelation.model.RelationOperation
 import no.fintlabs.autorelation.model.RelationSyncRule
@@ -44,6 +46,7 @@ class AutoRelationServiceTest {
                 block()
             }
         }
+    private val metricService: MetricService = mockk(relaxed = true)
 
     private var service: AutoRelationService =
         AutoRelationService(
@@ -56,6 +59,7 @@ class AutoRelationServiceTest {
             resourceContext,
             objectMapper,
             resourceLockService,
+            metricService,
         )
 
     private val relationUpdate: RelationUpdate = createRelationUpdate()
@@ -81,11 +85,40 @@ class AutoRelationServiceTest {
             every {
                 cacheService.getCache(relationUpdate.targetEntity.resourceName).get(targetId)
             } returns resource
+            every {
+                cacheService.getCache(relationUpdate.targetEntity.resourceName).put(any(), any(), any())
+            } returns true
 
-            service.applyOrBufferUpdate(relationUpdate)
+            service.process(relationUpdate)
 
             verify(exactly = 1) { linkService.mapLinks(relationUpdate.targetEntity.resourceName, any()) }
+            verify(exactly = 1) {
+                metricService.incrementUpdateApplied(
+                    relationUpdate.targetEntity.resourceName,
+                    relationUpdate.operation,
+                )
+            }
+            verify(exactly = 0) { metricService.incrementCachePutRejectedOlderTimestamp(any()) }
             verify { unresolvedRelationCache wasNot Called }
+        }
+
+        @Test
+        fun `should record cache put rejected metric when put returns false`() {
+            val resource = createElevFravar()
+            val targetId = relationUpdate.targetIds.first()
+
+            every {
+                cacheService.getCache(relationUpdate.targetEntity.resourceName).get(targetId)
+            } returns resource
+            every {
+                cacheService.getCache(relationUpdate.targetEntity.resourceName).put(any(), any(), any())
+            } returns false
+
+            service.process(relationUpdate)
+
+            verify(exactly = 1) {
+                metricService.incrementCachePutRejectedOlderTimestamp(relationUpdate.targetEntity.resourceName)
+            }
         }
 
         @Test
@@ -97,7 +130,7 @@ class AutoRelationServiceTest {
                 cacheService.getCache(addUpdate.targetEntity.resourceName).get(targetId)
             } returns null
 
-            service.applyOrBufferUpdate(addUpdate)
+            service.process(addUpdate)
 
             verify(exactly = 1) {
                 unresolvedRelationCache.registerRelation(
@@ -108,6 +141,60 @@ class AutoRelationServiceTest {
                     createdAt = addUpdate.timestamp,
                 )
             }
+            verify(exactly = 1) {
+                metricService.incrementUpdateBuffered(
+                    addUpdate.targetEntity.resourceName,
+                    RelationOperation.ADD,
+                )
+            }
+        }
+
+        @Test
+        fun `should record failed metric tagged UNEXPECTED_ERROR when an unexpected exception is thrown`() {
+            val resource = createElevFravar()
+            val targetId = relationUpdate.targetIds.first()
+
+            every {
+                cacheService.getCache(relationUpdate.targetEntity.resourceName).get(targetId)
+            } returns resource
+            every {
+                linkService.mapLinks(relationUpdate.targetEntity.resourceName, any())
+            } throws RuntimeException("boom")
+
+            service.process(relationUpdate)
+
+            verify(exactly = 1) {
+                metricService.incrementUpdateFailed(
+                    relationUpdate.targetEntity.resourceName,
+                    relationUpdate.operation,
+                    MetricReason.UNEXPECTED_ERROR,
+                )
+            }
+            verify(exactly = 0) { metricService.incrementUpdateApplied(any(), any()) }
+        }
+
+        @Test
+        fun `should record failed metric tagged with metricReason when AutoRelationException is thrown`() {
+            val resource = createElevFravar()
+            val targetId = relationUpdate.targetIds.first()
+
+            every {
+                cacheService.getCache(relationUpdate.targetEntity.resourceName).get(targetId)
+            } returns resource
+            every {
+                linkService.mapLinks(relationUpdate.targetEntity.resourceName, any())
+            } throws InvalidLinkException("rel")
+
+            service.process(relationUpdate)
+
+            verify(exactly = 1) {
+                metricService.incrementUpdateFailed(
+                    relationUpdate.targetEntity.resourceName,
+                    relationUpdate.operation,
+                    MetricReason.INVALID_LINK,
+                )
+            }
+            verify(exactly = 0) { metricService.incrementUpdateApplied(any(), any()) }
         }
 
         @Test
@@ -119,7 +206,7 @@ class AutoRelationServiceTest {
                 cacheService.getCache(deleteUpdate.targetEntity.resourceName).get(targetId)
             } returns null
 
-            service.applyOrBufferUpdate(deleteUpdate)
+            service.process(deleteUpdate)
 
             verify(exactly = 1) {
                 unresolvedRelationCache.removeRelation(
@@ -127,6 +214,12 @@ class AutoRelationServiceTest {
                     resourceId = targetId,
                     relationName = deleteUpdate.binding.relationName,
                     relationLink = deleteUpdate.binding.link,
+                )
+            }
+            verify(exactly = 1) {
+                metricService.incrementUpdateBuffered(
+                    deleteUpdate.targetEntity.resourceName,
+                    RelationOperation.DELETE,
                 )
             }
         }
@@ -217,6 +310,9 @@ class AutoRelationServiceTest {
             service.reconcileLinks(resourceName, resourceId, newResource)
 
             assert(newResource.links[relationName]?.contains(oldLink) == true)
+            verify(exactly = 1) {
+                metricService.incrementPreservedLinks(resourceName, relationName, 1)
+            }
         }
 
         @Test
@@ -244,6 +340,9 @@ class AutoRelationServiceTest {
             service.reconcileLinks(resourceName, resourceId, newResource)
 
             assert(newResource.links[relationName]?.contains(pendingLink) == true)
+            verify(exactly = 1) {
+                metricService.incrementHydratedLinks(resourceName, relationName, 1)
+            }
         }
     }
 

--- a/src/test/java/no/fintlabs/autorelation/RelationEventServiceTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/RelationEventServiceTest.kt
@@ -1,0 +1,206 @@
+package no.fintlabs.autorelation
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.fintlabs.autorelation.cache.RelationRuleRegistry
+import no.fintlabs.autorelation.kafka.RelationUpdateProducer
+import no.fintlabs.autorelation.model.EntityDescriptor
+import no.fintlabs.autorelation.model.MetricReason
+import no.fintlabs.autorelation.model.RelationOperation
+import no.fintlabs.autorelation.model.RelationSyncRule
+import no.fintlabs.autorelation.model.RelationUpdate
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.resource.ResourceConverter
+import no.novari.fint.model.FintMultiplicity
+import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
+import no.novari.fint.model.resource.Link
+import no.novari.fint.model.resource.utdanning.vurdering.ElevfravarResource
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RelationEventServiceTest {
+    private val resourceConverter: ResourceConverter = mockk(relaxed = true)
+    private val relationRuleRegistry: RelationRuleRegistry = mockk(relaxed = true)
+    private val consumerConfiguration: ConsumerConfiguration = mockk(relaxed = true)
+    private val relationUpdateProducer: RelationUpdateProducer = mockk(relaxed = true)
+    private val metricService: MetricService = mockk(relaxed = true)
+
+    private val service =
+        RelationEventService(
+            resourceConverter,
+            relationRuleRegistry,
+            consumerConfiguration,
+            relationUpdateProducer,
+            metricService,
+        )
+
+    private val resourceName = "elevfravar"
+    private val resourceId = "123"
+    private val targetType = EntityDescriptor("utdanning", "vurdering", "fravarsregistrering")
+
+    @BeforeEach
+    fun setUp() {
+        every { consumerConfiguration.domain } returns "utdanning"
+        every { consumerConfiguration.packageName } returns "vurdering"
+    }
+
+    @AfterEach
+    fun tearDown() = clearAllMocks()
+
+    @Test
+    fun `addRelations returns silently when no rules are registered`() {
+        every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns emptyList()
+
+        service.addRelations(resourceName, resourceId, mockk<Any>())
+
+        verify { relationUpdateProducer wasNot io.mockk.Called }
+        verify(exactly = 0) { metricService.incrementRuleSkipped(any(), any()) }
+    }
+
+    @Test
+    fun `addRelations records CONVERSION_FAILED when conversion throws`() {
+        every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns
+            listOf(buildRule(targetRelation = "fravarsregistrering", isToOne = false))
+        every { resourceConverter.convert(resourceName, any()) } throws RuntimeException("bad payload")
+
+        service.addRelations(resourceName, resourceId, mockk<Any>())
+
+        verify(exactly = 1) {
+            metricService.incrementRuleSkipped(resourceName, MetricReason.CONVERSION_FAILED)
+        }
+        verify { relationUpdateProducer wasNot io.mockk.Called }
+    }
+
+    @Test
+    fun `publishAll records NO_TARGETS when toRelationUpdate yields null`() {
+        // non-mandatory rule + resource with no link for that relation -> getTargetIds returns null
+        val rule = buildRule(targetRelation = "fravarsregistrering", isToOne = false)
+        val resource = createElevFravar(resourceId)
+
+        every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns listOf(rule)
+
+        service.removeRelations(resourceName, resourceId, resource)
+
+        verify(exactly = 1) {
+            metricService.incrementRuleSkipped(resourceName, MetricReason.NO_TARGETS)
+        }
+        verify { relationUpdateProducer wasNot io.mockk.Called }
+    }
+
+    @Test
+    fun `publishAll records MISSING_MANDATORY_LINK when mandatory rule has no link`() {
+        // mandatory rule + resource with no link for that relation -> getTargetIds throws
+        val rule = buildRule(targetRelation = "fravarsregistrering", isToOne = true)
+        val resource = createElevFravar(resourceId)
+
+        every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns listOf(rule)
+
+        service.removeRelations(resourceName, resourceId, resource)
+
+        verify(exactly = 1) {
+            metricService.incrementRuleSkipped(resourceName, MetricReason.MISSING_MANDATORY_LINK)
+        }
+    }
+
+    @Test
+    fun `publishAll records INVALID_LINK when target link href is malformed`() {
+        val rule = buildRule(targetRelation = "fravarsregistrering", isToOne = false)
+        val resource =
+            createElevFravar(resourceId).apply {
+                addLink("fravarsregistrering", Link.with("badhrefnoslash"))
+            }
+
+        every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns listOf(rule)
+
+        service.removeRelations(resourceName, resourceId, resource)
+
+        verify(exactly = 1) {
+            metricService.incrementRuleSkipped(resourceName, MetricReason.INVALID_LINK)
+        }
+    }
+
+    @Test
+    fun `publishAll records VALIDATION_ID_MISMATCH when resourceId is not in identifikators`() {
+        val rule = buildRule(targetRelation = "fravarsregistrering", isToOne = false)
+        // resource has id "999" but caller passes resourceId "123" -> toLink throws
+        val resource =
+            createElevFravar("999").apply {
+                addLink("fravarsregistrering", Link.with("systemid/abc"))
+            }
+
+        every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns listOf(rule)
+
+        service.removeRelations(resourceName, resourceId, resource)
+
+        verify(exactly = 1) {
+            metricService.incrementRuleSkipped(resourceName, MetricReason.VALIDATION_ID_MISMATCH)
+        }
+    }
+
+    @Test
+    fun `publishAll records UNEXPECTED_ERROR when producer throws unknown exception`() {
+        val rule = buildRule(targetRelation = "fravarsregistrering", isToOne = false)
+        val resource =
+            createElevFravar(resourceId).apply {
+                addLink("fravarsregistrering", Link.with("systemid/abc"))
+            }
+
+        every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns listOf(rule)
+        every { relationUpdateProducer.publishRelationUpdate(any(), any(), any()) } throws RuntimeException("kafka down")
+
+        service.removeRelations(resourceName, resourceId, resource)
+
+        verify(exactly = 1) {
+            metricService.incrementRuleSkipped(resourceName, MetricReason.UNEXPECTED_ERROR)
+        }
+    }
+
+    @Test
+    fun `publishAll publishes update on happy path and does not increment skip metric`() {
+        val rule = buildRule(targetRelation = "fravarsregistrering", isToOne = false)
+        val resource =
+            createElevFravar(resourceId).apply {
+                addLink("fravarsregistrering", Link.with("systemid/abc"))
+            }
+
+        every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns listOf(rule)
+
+        service.removeRelations(resourceName, resourceId, resource)
+
+        verify(exactly = 1) {
+            relationUpdateProducer.publishRelationUpdate(
+                match<RelationUpdate> { it.operation == RelationOperation.DELETE },
+                resourceName,
+                resourceId,
+            )
+        }
+        verify(exactly = 0) { metricService.incrementRuleSkipped(any(), any()) }
+    }
+
+    private fun createElevFravar(id: String): ElevfravarResource =
+        ElevfravarResource().apply {
+            systemId = Identifikator().apply { identifikatorverdi = id }
+        }
+
+    /**
+     * `isToOne = true` -> targetMultiplicity ONE_TO_ONE, isMandatory = true.
+     * `isToOne = false` -> NONE_TO_MANY/NONE_TO_MANY, isMandatory = false.
+     */
+    private fun buildRule(
+        targetRelation: String,
+        isToOne: Boolean,
+    ): RelationSyncRule {
+        val targetMult = if (isToOne) FintMultiplicity.ONE_TO_ONE else FintMultiplicity.NONE_TO_MANY
+        return RelationSyncRule(
+            targetRelation = targetRelation,
+            inverseRelation = "elevfravar",
+            targetType = targetType,
+            targetMultiplicity = targetMult,
+            inverseMultiplicity = FintMultiplicity.NONE_TO_MANY,
+            isSource = true,
+        )
+    }
+}

--- a/src/test/java/no/fintlabs/autorelation/RelationEventServiceTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/RelationEventServiceTest.kt
@@ -149,7 +149,13 @@ class RelationEventServiceTest {
             }
 
         every { relationRuleRegistry.getRules(any(), any(), resourceName) } returns listOf(rule)
-        every { relationUpdateProducer.publishRelationUpdate(any(), any(), any()) } throws RuntimeException("kafka down")
+        every {
+            relationUpdateProducer.publishRelationUpdate(
+                any(),
+                any(),
+                any(),
+            )
+        } throws RuntimeException("kafka down")
 
         service.removeRelations(resourceName, resourceId, resource)
 

--- a/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/UnresolvedRelationCacheTest.kt
@@ -2,6 +2,7 @@ package no.fintlabs.autorelation
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import no.fintlabs.autorelation.buffer.UnresolvedRelationCache
 import no.fintlabs.consumer.config.AutorelationConfig
 import no.fintlabs.consumer.config.ConsumerConfiguration
@@ -14,20 +15,25 @@ import java.time.Duration
 
 class UnresolvedRelationCacheTest {
     private lateinit var service: UnresolvedRelationCache
+    private lateinit var metricService: MetricService
 
     private val resource = "person"
     private val resourceId = "123"
     private val relation = "manager"
 
-    private fun cacheWithTtl(ttl: Duration): UnresolvedRelationCache {
+    private fun cacheWithTtl(
+        ttl: Duration,
+        metrics: MetricService = mockk(relaxed = true),
+    ): UnresolvedRelationCache {
         val config = mockk<ConsumerConfiguration>()
         every { config.autorelation } returns AutorelationConfig(buffer = AutorelationConfig.BufferConfig(ttl = ttl))
-        return UnresolvedRelationCache(config)
+        return UnresolvedRelationCache(config, metrics)
     }
 
     @BeforeEach
     fun setup() {
-        service = cacheWithTtl(Duration.ofDays(7))
+        metricService = mockk(relaxed = true)
+        service = cacheWithTtl(Duration.ofDays(7), metricService)
     }
 
     @Test
@@ -129,6 +135,17 @@ class UnresolvedRelationCacheTest {
             service.cleanUp()
 
             assertEquals(emptyList<Link>(), service.takeRelations(resource, resourceId, relation))
+        }
+
+        @Test
+        fun `expired entry triggers incrementBufferExpired tagged with link count`() {
+            val eightDaysAgo = System.currentTimeMillis() - Duration.ofDays(8).toMillis()
+            val link = Link.with("http://expired-link")
+
+            service.registerRelation(resource, resourceId, relation, link, eightDaysAgo)
+            service.cleanUp()
+
+            verify(exactly = 1) { metricService.incrementBufferExpired(resource, relation, 1) }
         }
     }
 

--- a/src/test/java/no/fintlabs/autorelation/kafka/RelationUpdateProducerTest.kt
+++ b/src/test/java/no/fintlabs/autorelation/kafka/RelationUpdateProducerTest.kt
@@ -1,0 +1,72 @@
+package no.fintlabs.autorelation.kafka
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.fintlabs.autorelation.model.EntityDescriptor
+import no.fintlabs.autorelation.model.RelationBinding
+import no.fintlabs.autorelation.model.RelationOperation
+import no.fintlabs.autorelation.model.RelationUpdate
+import no.fintlabs.consumer.config.ConsumerConfiguration
+import no.fintlabs.consumer.config.OrgId
+import no.fintlabs.consumer.kafka.KafkaThroughputMetrics
+import no.novari.fint.model.resource.Link
+import no.novari.kafka.producing.ParameterizedProducerRecord
+import no.novari.kafka.producing.ParameterizedTemplate
+import no.novari.kafka.producing.ParameterizedTemplateFactory
+import org.junit.jupiter.api.Test
+import org.springframework.kafka.support.SendResult
+import java.util.concurrent.CompletableFuture
+
+class RelationUpdateProducerTest {
+    private val factory: ParameterizedTemplateFactory = mockk()
+    private val template: ParameterizedTemplate<RelationUpdate> = mockk()
+    private val consumerConfiguration: ConsumerConfiguration = mockk(relaxed = true)
+    private val kafkaThroughputMetrics: KafkaThroughputMetrics = mockk(relaxed = true)
+
+    private val update =
+        RelationUpdate(
+            targetEntity = EntityDescriptor("utdanning", "vurdering", "elevfravar"),
+            targetIds = listOf("123"),
+            binding = RelationBinding(relationName = "fravarsregistrering", link = Link.with("systemid/abc")),
+            operation = RelationOperation.ADD,
+        )
+
+    private fun newProducer(future: CompletableFuture<SendResult<String, RelationUpdate>>): RelationUpdateProducer {
+        every { factory.createTemplate(RelationUpdate::class.java) } returns template
+        every { template.send(any<ParameterizedProducerRecord<RelationUpdate>>()) } returns future
+        every { consumerConfiguration.orgId } returns OrgId.from("fintlabs.no")
+        return RelationUpdateProducer(factory, consumerConfiguration, kafkaThroughputMetrics)
+    }
+
+    @Test
+    fun `records published when send completes successfully`() {
+        val sendResult: SendResult<String, RelationUpdate> = mockk(relaxed = true)
+        val producer = newProducer(CompletableFuture.completedFuture(sendResult))
+
+        producer.publishRelationUpdate(update, "elev", "elev-1").join()
+
+        verify(exactly = 1) {
+            kafkaThroughputMetrics.recordRelationUpdateProduced("elevfravar", "ADD", "published")
+        }
+        verify(exactly = 0) {
+            kafkaThroughputMetrics.recordRelationUpdateProduced(any(), any(), "failed")
+        }
+    }
+
+    @Test
+    fun `records failed when send completes exceptionally`() {
+        val failed: CompletableFuture<SendResult<String, RelationUpdate>> = CompletableFuture()
+        failed.completeExceptionally(RuntimeException("broker unavailable"))
+        val producer = newProducer(failed)
+
+        runCatching { producer.publishRelationUpdate(update, "elev", "elev-1").join() }
+
+        verify(exactly = 1) {
+            kafkaThroughputMetrics.recordRelationUpdateProduced("elevfravar", "ADD", "failed")
+        }
+        verify(exactly = 0) {
+            kafkaThroughputMetrics.recordRelationUpdateProduced(any(), any(), "published")
+        }
+    }
+}

--- a/src/test/java/no/fintlabs/consumer/kafka/entity/EntityProcessingServiceTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/entity/EntityProcessingServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.fintlabs.autorelation.AutoRelationService
+import no.fintlabs.autorelation.MetricService
 import no.fintlabs.autorelation.RelationEventService
 import no.fintlabs.cache.CacheService
 import no.fintlabs.cache.FintCache
@@ -31,6 +32,7 @@ class EntityProcessingServiceTest {
     private val syncTrackerService = mockk<SyncTrackerService>(relaxed = true)
     private val cache = mockk<FintCache<FintResource>>(relaxed = true)
     private val meterRegistry = SimpleMeterRegistry()
+    private val metricService = mockk<MetricService>(relaxed = true)
     private var resourceLockService: ResourceLockService =
         mockk {
             every { withLock(any(), any(), any()) } answers {
@@ -53,6 +55,7 @@ class EntityProcessingServiceTest {
                 syncTrackerService,
                 meterRegistry,
                 resourceLockService,
+                metricService,
             )
         every { cacheService.getCache(any()) } returns cache
         every { consumerConfiguration.orgId } returns OrgId.from("org-123")

--- a/src/test/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumerTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/entity/RelationUpdateConsumerTest.kt
@@ -100,6 +100,17 @@ class RelationUpdateConsumerTest {
 
         relationUpdateConsumer.consumeRecord(consumerRecord)
 
-        verify(exactly = 1) { autoRelationService.applyOrBufferUpdate(any()) }
+        verify(exactly = 1) { autoRelationService.process(any()) }
+    }
+
+    @Test
+    fun `records consumer metric when processing completes`() {
+        every { relationUpdate.targetEntity } returns createEntityDescriptor("d", "p", "resource")
+
+        relationUpdateConsumer.consumeRecord(consumerRecord)
+
+        verify(exactly = 1) {
+            kafkaThroughputMetrics.recordRelationUpdateConsumer("resource", any())
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes silent-drop points in the relation-update pipeline and adds metrics so we can answer the question *"where do relation updates disappear?"* by joining the producer, consumer, and per-target verdicts.

### Loss points closed
- `AutoRelationService.apply` previously caught all exceptions and silently swallowed them. It now catches `AutoRelationException` (tagged with `e.metricReason`, `log.warn`) and unexpected `Exception` (tagged `UNEXPECTED_ERROR`, `log.error`) — the loop continues so one bad target doesn't halt siblings, but every drop is now visible in metrics + logs.
- `putInCache` was ignoring `cache.put`'s `Boolean` return. It now records `cache.put_rejected_older_timestamp` on rejection, matching the existing producer-side path in `EntityProcessingService`.
- `FintResource.deepCopy` now throws a typed `DeepCopyException` (tagged `DEEP_COPY_FAILED`) instead of a raw `JsonProcessingException`.

### New metrics
- `update.failed{resource, operation, reason}` — per-target failure counter on the apply path
- Re-wired `recordRelationUpdateConsumer` (records counter + processing-duration timer) at the consumer boundary; tag set is `resource` only since per-target outcomes live in `MetricService`
- `KafkaThroughputMetrics` got a class-level KDoc explaining the transport-vs-business-outcome split and the produced-vs-(applied+buffered+failed) debugging shape

### Renames in `AutoRelationService`
For symmetry and clarity:
- `applyOrBufferUpdate` → `process`
- `applyUpdateToCachedResource` → `RelationUpdate.apply`
- `bufferRelation` → `RelationUpdate.buffer`

Each branch (`apply` / `buffer`) now owns its own outcome metric so success and failure stay mutually exclusive.

### Test coverage
- Positive assertions added for every metric path in `AutoRelationServiceTest` (`update.applied`, `update.buffered`, `cache.put_rejected`, `preserved_links`, `hydrated_links`)
- New `RelationEventServiceTest` (8 tests) covering all five `incrementRuleSkipped` reason mappings (`NO_TARGETS`, `CONVERSION_FAILED`, `MISSING_MANDATORY_LINK`, `INVALID_LINK`, `VALIDATION_ID_MISMATCH`, `UNEXPECTED_ERROR`)
- New `RelationUpdateProducerTest` covering both `published` and `failed` outcomes via driven `CompletableFuture`s
- `UnresolvedRelationCacheTest` extended to verify `incrementBufferExpired` fires on TTL eviction
- `RelationUpdateConsumerTest` extended for the re-wired consumer-side counter