### PR TITLE
fix: gate relation removal on autorelation.enabled flag

### DIFF
--- a/src/main/java/no/fintlabs/cache/CacheEvictionService.kt
+++ b/src/main/java/no/fintlabs/cache/CacheEvictionService.kt
@@ -70,8 +70,10 @@ class CacheEvictionService(
             cache
                 .evictExpired(startTimestamp)
                 .forEach {
-                    timed(resourceName, "eviction.relation.removeRelations") {
-                        publishRelationDeleteRequest(resourceName, it.first, it.second)
+                    if (consumerConfiguration.autorelation.enabled) {
+                        timed(resourceName, "eviction.relation.removeRelations") {
+                            publishRelationDeleteRequest(resourceName, it.first, it.second)
+                        }
                     }
                 }
         }

--- a/src/main/java/no/fintlabs/consumer/kafka/entity/EntityProcessingService.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/entity/EntityProcessingService.kt
@@ -56,8 +56,10 @@ class EntityProcessingService(
         timed(record.resourceName, "cache.get") {
             cache.get(record.key)
         }?.let {
-            timed(record.resourceName, "relation.removeRelations") {
-                relationEventService.removeRelations(record.resourceName, record.key, it)
+            if (consumerConfiguration.autorelation.enabled) {
+                timed(record.resourceName, "relation.removeRelations") {
+                    relationEventService.removeRelations(record.resourceName, record.key, it)
+                }
             }
         }
 

--- a/src/test/java/no/fintlabs/cache/CacheEvictionServiceTest.kt
+++ b/src/test/java/no/fintlabs/cache/CacheEvictionServiceTest.kt
@@ -7,6 +7,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import no.fintlabs.autorelation.RelationEventService
+import no.fintlabs.consumer.config.AutorelationConfig
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.config.OrgId
 import no.novari.fint.model.resource.FintResource
@@ -33,6 +34,7 @@ class CacheEvictionServiceTest {
         consumerConfiguration =
             mockk {
                 every { orgId } returns OrgId.from("org-123")
+                every { autorelation } returns AutorelationConfig(enabled = true)
             }
         cacheEvictionService =
             CacheEvictionService(
@@ -57,7 +59,7 @@ class CacheEvictionServiceTest {
     }
 
     @Test
-    fun `calls removeRelations for every evicted object`() {
+    fun `calls removeRelations for every evicted object when autorelation enabled`() {
         val resourceName = "elevfravar"
         val key1 = "k1"
         val key2 = "k2"
@@ -73,6 +75,19 @@ class CacheEvictionServiceTest {
             relationEventService.removeRelations(resourceName, key1, resource1)
             relationEventService.removeRelations(resourceName, key2, resource2)
         }
+    }
+
+    @Test
+    fun `skips removeRelations for evicted objects when autorelation disabled`() {
+        every { consumerConfiguration.autorelation } returns AutorelationConfig(enabled = false)
+        val resourceName = "elevfravar"
+
+        val cache = cacheService.getCache(resourceName)
+        cache.put("k1", ElevfravarResource(), 1)
+        cache.put("k2", ElevfravarResource(), 2)
+        cacheEvictionService.evictExpired(resourceName, Long.MAX_VALUE)
+
+        verify(exactly = 0) { relationEventService.removeRelations(any(), any(), any()) }
     }
 
     @Test

--- a/src/test/java/no/fintlabs/consumer/kafka/entity/EntityProcessingServiceTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/entity/EntityProcessingServiceTest.kt
@@ -82,14 +82,26 @@ class EntityProcessingServiceTest {
     }
 
     @Test
-    fun `delete removes relations when cache entry exists`() {
+    fun `delete removes relations when cache entry exists and autorelation enabled`() {
+        every { consumerConfiguration.autorelation } returns AutorelationConfig(enabled = true)
         val existing = mockk<FintResource>()
         val record = recordWith(resource = null, syncType = null)
         every { cache.get(record.key) } returns existing
 
         service.processEntityConsumerRecord(record)
 
-        verify { relationEventService.removeRelations(record.resourceName, record.key, existing) }
+        verify(exactly = 1) { relationEventService.removeRelations(record.resourceName, record.key, existing) }
+    }
+
+    @Test
+    fun `delete skips removeRelations when autorelation disabled`() {
+        val existing = mockk<FintResource>()
+        val record = recordWith(resource = null, syncType = null)
+        every { cache.get(record.key) } returns existing
+
+        service.processEntityConsumerRecord(record)
+
+        verify(exactly = 0) { relationEventService.removeRelations(any(), any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
The entity delete path in EntityProcessingService and the TTL eviction path in CacheEvictionService were calling RelationEventService.removeRelations unconditionally, bypassing the autorelation.enabled flag that already gated the add/reconcile path. Both call sites now check the flag, matching the existing behaviour in addToCache.