### PR TITLE
fix: track request in event status cache on publish to close status race

### DIFF
--- a/src/integrationTest/java/no/fintlabs/consumer/integration/EventIT.kt
+++ b/src/integrationTest/java/no/fintlabs/consumer/integration/EventIT.kt
@@ -15,10 +15,12 @@ import org.awaitility.kotlin.await
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.kafka.listener.MessageListenerContainer
 import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.TestPropertySource
@@ -63,6 +65,10 @@ class EventIT {
 
     @Autowired
     lateinit var cacheService: CacheService
+
+    @Autowired
+    @Qualifier("requestFintEventRequestListenerContainer")
+    lateinit var requestListenerContainer: MessageListenerContainer
 
     private val resourceName = "elev"
     private val elevId = "123"
@@ -182,6 +188,23 @@ class EventIT {
                 .exchange()
                 .expectStatus()
                 .isAccepted
+        }
+    }
+
+    @Test
+    fun `status endpoint returns 202 right after publish, even when the request event is never consumed`() {
+        requestListenerContainer.stop()
+        try {
+            val corrId = postResourceAndGetCorrId()
+
+            client
+                .get()
+                .uri("/$resourceName/status/$corrId")
+                .exchange()
+                .expectStatus()
+                .isAccepted
+        } finally {
+            requestListenerContainer.start()
         }
     }
 

--- a/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventService.kt
+++ b/src/main/java/no/fintlabs/consumer/kafka/event/RequestFintEventService.kt
@@ -6,6 +6,7 @@ import no.fintlabs.adapter.operation.OperationType
 import no.fintlabs.consumer.config.ConsumerConfiguration
 import no.fintlabs.consumer.config.EventCacheProperties
 import no.fintlabs.consumer.resource.ResourceConverter
+import no.fintlabs.consumer.resource.event.EventStatusCache
 import no.novari.fint.model.resource.FintResource
 import org.springframework.stereotype.Service
 import java.time.Clock
@@ -19,6 +20,7 @@ class RequestFintEventService(
     private val clock: Clock = Clock.systemUTC(),
     private val resourceConverter: ResourceConverter,
     private val requestFintEventProducer: RequestFintEventProducer,
+    private val eventStatusCache: EventStatusCache,
 ) {
     fun createAndPublish(
         resourceName: String,
@@ -29,6 +31,7 @@ class RequestFintEventService(
             .toFintResource(resourceName)
             .toRequestFintEvent(resourceName, operationType)
             .also { requestFintEventProducer.publish(it) }
+            .also { eventStatusCache.trackRequest(it) }
 
     fun createAndPublish(
         resourceName: String,

--- a/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventServiceTest.kt
+++ b/src/test/java/no/fintlabs/consumer/kafka/event/RequestFintEventServiceTest.kt
@@ -11,6 +11,7 @@ import no.fintlabs.consumer.config.EventCacheProperties
 import no.fintlabs.consumer.config.EventCacheProperties.LifeCycle
 import no.fintlabs.consumer.config.OrgId
 import no.fintlabs.consumer.resource.ResourceConverter
+import no.fintlabs.consumer.resource.event.EventStatusCache
 import no.novari.fint.model.resource.FintResource
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -29,6 +30,7 @@ class RequestFintEventServiceTest {
     private val clock = Clock.fixed(Instant.parse("2020-05-24T14:00:00Z"), ZoneOffset.UTC)
     private val resourceConverter = mockk<ResourceConverter>()
     private val producer = mockk<RequestFintEventProducer>(relaxed = true)
+    private val eventStatusCache = mockk<EventStatusCache>(relaxed = true)
 
     private lateinit var service: RequestFintEventService
 
@@ -42,6 +44,7 @@ class RequestFintEventServiceTest {
                 clock = clock,
                 resourceConverter = resourceConverter,
                 requestFintEventProducer = producer,
+                eventStatusCache = eventStatusCache,
             )
 
         every { config.orgId } returns OrgId.from("fintlabs.no")
@@ -117,6 +120,19 @@ class RequestFintEventServiceTest {
         val event = service.createAndPublish(resourceName, fintResource, OperationType.CREATE)
 
         verify(exactly = 1) { producer.publish(event) }
+    }
+
+    @Test
+    fun `createAndPublish tracks the request in the event status cache`() {
+        val resourceName = "elevfravar"
+        val fintResource = mockk<FintResource>()
+
+        every { resourceConverter.convertAndMapLinks(resourceName, any()) } returns fintResource
+        every { props.getLifeCycleConfig(resourceName) } returns LifeCycle(ttl = Duration.ofMinutes(2))
+
+        val event = service.createAndPublish(resourceName, fintResource, OperationType.CREATE)
+
+        verify(exactly = 1) { eventStatusCache.trackRequest(event) }
     }
 
     @Test


### PR DESCRIPTION
POST/PUT publish a RequestFintEvent to Kafka and immediately return 202 with a status location, but the request was only tracked once RequestFintEventConsumer read it back off the topic. A status poll arriving in that window found no tracked request and returned 410 GONE instead of 202 Accepted.

Track the request in EventStatusCache synchronously at publish time, so the status endpoint reports 202 as soon as the client receives the 202. RequestFintEventConsumer is kept for restart durability; the resulting duplicate trackRequest is idempotent on corrId.

Add a deterministic EventIT that stops the request consumer to prove the 202 comes from the publish path, plus a unit test asserting createAndPublish tracks the request.